### PR TITLE
Use Jrun to manage (maven) Java dependencies

### DIFF
--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -14,8 +14,11 @@ def _init_jvm():
             PYJNIUS_JAR = os.environ[PYJNIUS_JAR_STR]
             jnius_config.add_classpath(PYJNIUS_JAR)
         except KeyError as e:
-            print("Path to pyjnius.jar not defined! Use environment variable {} to define it.".format(PYJNIUS_JAR_STR))
-            raise e
+            if e.args[0] == PYJNIUS_JAR_STR:
+                _logger.error('Unable to import scyjava: %s environment variable not defined.', PYJNIUS_JAR_STR)
+            else:
+                raise e
+            return None
 
     endpoints = scyjava_config.get_endpoints()
     repositories = scyjava_config.get_repositories()
@@ -37,7 +40,9 @@ def _init_jvm():
         return jnius
     except KeyError as e:
         if e.args[0] == 'JAVA_HOME':
-            _logger.info('Unable to import scyjava: JAVA_HOME environment variable not defined, cannot import jnius.')
+            _logger.error('Unable to import scyjava: JAVA_HOME environment variable not defined, cannot import jnius.')
+        else:
+            raise e
         return None
 
 jnius = _init_jvm()

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -1,73 +1,52 @@
-def _get_logger(name):
-    import logging
-    return logging.getLogger(name)
+# from .version import __version__ as version
+
+import logging
+import os
+
+_logger = logging.getLogger(__name__)
 
 def _init_jvm():
-
+    import scyjava_config
     import jnius_config
+    import jrun
 
-    import os
+    PYJNIUS_JAR_STR = 'PYJNIUS_JAR'
+    if PYJNIUS_JAR_STR not in globals():
+        try:
+            PYJNIUS_JAR = os.environ[PYJNIUS_JAR_STR]
+            jnius_config.add_classpath(PYJNIUS_JAR)
+        except KeyError as e:
+            print("Path to pyjnius.jar not defined! Use environment variable {} to define it.".format(PYJNIUS_JAR_STR))
+            raise e
 
-    CLASSPATH_STR = 'SCYJAVA_CLASSPATH'
+    endpoints = scyjava_config.get_endpoints()
+    repositories = scyjava_config.get_repositories()
 
-    CLASSPATH = os.environ[CLASSPATH_STR].split(jnius_config.split_char) if CLASSPATH_STR in os.environ else []
+    _logger.debug('Adding jars from endpoints %s', endpoints)
 
-    jnius_config.add_classpath(*CLASSPATH)
+    if len(endpoints) > 0:
+        _, workspace = jrun.resolve_dependencies(
+            '+'.join(endpoints[:1] + sorted(endpoints[1:])),
+            m2_repo=scyjava_config.get_m2_repo(),
+            cache_dir=scyjava_config.get_cache_dir(),
+            repositories=repositories,
+            verbose=scyjava_config.get_verbose()
+        )
+        jnius_config.add_classpath(os.path.join(workspace, '*'))
 
-    JVM_OPTIONS_STR = 'SCYJAVA_JVM_OPTIONS'
+    try:
+        import jnius
+        return jnius
+    except KeyError as e:
+        if e.args[0] == 'JAVA_HOME':
+            _logger.info('Unable to import scyjava: JAVA_HOME environment variable not defined, cannot import jnius.')
+        return None
 
-    if JVM_OPTIONS_STR in os.environ:
-        jnius_config.add_options(*os.environ[JVM_OPTIONS_STR].split(' '))
-
-    import jnius
-
-    scijava = None # jnius.autoclass('some scijava grab class')
-
-    return jnius_config, jnius, scijava
-
-logger = _get_logger('scyjava')
-
-config, _jnius, _scijava  = _init_jvm()
-
-from jnius import autoclass as _autoclass, cast as _cast
-
-# for now, use grape directly:
-_HashMap     = _autoclass('java.util.HashMap')
-_GrapeIvy    = _autoclass('groovy.grape.GrapeIvy')
-_grapeIvy    = _GrapeIvy()
-_classLoader = _autoclass('groovy.lang.GroovyClassLoader')()
-
-def _default_map(**extra_options):
-    m = _HashMap()
-    m.put('classLoader', _classLoader)
-    m.put('autoDownload', 'true')
-    m.put("noExceptions", 'false')
-    for k, v in extra_options.items():
-        m.put(k, v)
-    return m
-
-def repository(url, name=None, **grape_options):
-    m = _default_map(**grape_options)
-    m.put('name', name)
-    m.put('root', url)
-    return _grapeIvy.addResolver(m)
-
-repository('http://maven.imagej.net/content/groups/public', 'imagej')
+jnius = _init_jvm()
+if (jnius == None):
+    raise ImportError('Unable to import scyjava dependency jnius.')
 
 
-def dependency(groupId, artifactId, version=None, **grape_options):
-    m = _default_map(**grape_options)
-    m.put('artifactId', artifactId)
-    m.put('groupId', groupId)
-    m.put('version', version)
-    return _grapeIvy.grab(m)
 
-def import_class(clazz):
-    return _autoclass( clazz )
-
-def list_grapes():
-    grapes = _grapeIvy.enumerateGrapes()
-    grapes = {k : grapes.get(k).toString() for k in grapes.keySet().toArray()}
-    return grapes
 
 

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -8,6 +8,11 @@ def _init_jvm():
     import jnius_config
     import jrun
 
+    if jnius_config.vm_running:
+        _logger.warning('JVM is already running, will not add endpoints to classpath -- required classes might not be on classpath..')
+        import jnius
+        return jnius
+
     PYJNIUS_JAR_STR = 'PYJNIUS_JAR'
     if PYJNIUS_JAR_STR not in globals():
         try:

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -1,5 +1,3 @@
-# from .version import __version__ as version
-
 import logging
 import os
 

--- a/scyjava_config.py
+++ b/scyjava_config.py
@@ -21,6 +21,8 @@ import logging
 import jnius_config
 import pathlib
 
+version = '0.1.0-dev'
+
 _logger = logging.getLogger(__name__)
 
 _endpoints    = []

--- a/scyjava_config.py
+++ b/scyjava_config.py
@@ -1,0 +1,118 @@
+__all__ = (
+    'add_endpoints',
+    'get_endpoints',
+    'add_repositories',
+    'get_repositories',
+    'set_verbose',
+    'get_verbose',
+    'set_cache_dir',
+    'get_cache_dir',
+    'set_m2_repo',
+    'get_m2_repo',
+    'set_options',
+    'add_options',
+    'get_options',
+    'set_classpath',
+    'add_classpath',
+    'get_classpath',
+    'expand_classpath')
+
+import logging
+import jnius_config
+import pathlib
+
+_logger = logging.getLogger(__name__)
+
+_endpoints    = []
+_repositories = {}
+_verbose      = 0
+_cache_dir    = pathlib.Path.home() / '.jrun'
+_m2_repo      = pathlib.Path.home() / '.m2' / 'repository'
+
+
+def add_endpoints(*endpoints):
+    global _endpoints
+    _logger.debug('Adding endpoints %s to %s', endpoints, _endpoints)
+    _endpoints.extend(endpoints)
+
+
+def get_endpoints():
+    global _endpoints
+    return _endpoints
+
+
+def add_repositories(*args, **kwargs):
+    global _repositories
+    for arg in args:
+        _logger.debug('Adding repositories %s to %s', arg, _repositories)
+        _repositories.update(arg)
+    _logger.debug('Adding repositories %s to %s', kwargs, _repositories)
+    _repositories.update(kwargs)
+
+
+def get_repositories():
+    global _repositories
+    return _repositories
+
+
+def set_verbose(level):
+    global _verbose
+    _logger.debug('Setting verbose level to %d (was %d)', level, _verbose)
+    _verbose = level
+
+
+def get_verbose():
+    global _verbose
+    return _verbose
+
+
+def set_cache_dir(dir):
+    global _cache_dir
+    _logger.debug('Setting cache dir to %s (was %s)', dir, _cache_dir)
+    _cache_dir = dir
+
+
+def get_cache_dir():
+    global _cache_dir
+    return _cache_dir
+
+
+def set_m2_repo(dir):
+    global _m2_repo
+    _logger.debug('Setting m2 repo dir to %s (was %s)', dir, _m2_repo)
+    _m2_repo = dir
+
+
+def get_m2_repo():
+    global _m2_repo
+    return _m2_repo
+
+
+# directly delegating to jnius_config
+def add_classpath(*path):
+    jnius_config.add_classpath(*path)
+
+
+def set_classpath(*path):
+    jnius_config.set_classpath(*path)
+
+
+def get_classpath():
+    return jnius_config.get_classpath()
+
+
+def add_options(*opts):
+    jnius_config.add_options(*opts)
+
+
+def set_options(*opts):
+    jnius_config.set_options(*opts)
+
+
+def get_options():
+    return jnius_config.get_options()
+
+
+def expand_classpath():
+    return jnius_config.expand_classpath()
+

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@ import setuptools
 
 setuptools.setup(
     name='scyjava',
-    packages=['scyjava']
+    packages=['scyjava'],
+    py_modules=['scyjava_config'],
+    version='0.1.0-dev',
+    author='Philipp Hanslovsky',
+    author_email='hanslovskyp@janelia.hhmi.org',
+    description='scyjava',
+    url='https://github.com/scijava/scyjava',
+    install_requires=['pyjnius', 'jrun']
     )
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 import setuptools
+import scyjava_config
 
 setuptools.setup(
     name='scyjava',
     packages=['scyjava'],
     py_modules=['scyjava_config'],
-    version='0.1.0-dev',
+    version=scyjava_config.version,
     author='Philipp Hanslovsky',
     author_email='hanslovskyp@janelia.hhmi.org',
     description='scyjava',


### PR DESCRIPTION
Example:
```python
import scyjava_config
import time

scyjava_config.add_endpoints('net.imagej:imagej')
scyjava_config.set_verbose(2)

from scyjava import jnius

ImageJ = jnius.autoclass('net.imagej.ImageJ')
ij = ImageJ()
ij.ui().showUI()

while True:
    time.sleep(0.5)
```

Fixes #3 