### PR TITLE
Autodetect pyjnius.jar and JAVA_HOME when not explicitly set

### DIFF
--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -29,6 +29,21 @@ def _init_jvm():
             _logger.error('Unable to import scyjava: pyjnius JAR not found.')
             return None
 
+    # attempt to set JAVA_HOME if the environment variable is not set.
+    JAVA_HOME_STR = 'JAVA_HOME'
+    if JAVA_HOME_STR not in globals():
+        JAVA_HOME = None
+        try:
+            JAVA_HOME = os.environ[JAVA_HOME_STR]
+        except KeyError as e:
+            JAVA_HOME = sys.prefix
+        # TODO is this necessary?
+        if Path(JAVA_HOME).is_dir():
+            os.environ['JAVA_HOME'] = JAVA_HOME
+        else:
+            _logger.error('Unable to import scyjava: jre not found')
+            return None
+
     endpoints = scyjava_config.get_endpoints()
     repositories = scyjava_config.get_repositories()
 

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -23,7 +23,7 @@ def _init_jvm():
         try:
             PYJNIUS_JAR = os.environ[PYJNIUS_JAR_STR]
         except KeyError as e:
-            PYJNIUS_JAR = sys.prefix + '/share/pyjnius/pyjnius.jar'
+            PYJNIUS_JAR = os.path.join(sys.prefix, 'share', 'pyjnius', 'pyjnius.jar')
         if Path(PYJNIUS_JAR).is_file():
             jnius_config.add_classpath(PYJNIUS_JAR)
         else:

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -15,14 +15,15 @@ def _init_jvm():
         import jnius
         return jnius
 
+    # attempt to find pyjnius.jar if the envrionment variable is not set.
     PYJNIUS_JAR_STR = 'PYJNIUS_JAR'
     if PYJNIUS_JAR_STR not in globals():
         PYJNIUS_JAR = None
         try:
-            PYJNIUS_JAR = Path(os.environ[PYJNIUS_JAR_STR])
+            PYJNIUS_JAR = os.environ[PYJNIUS_JAR_STR]
         except KeyError as e:
-            PYJNIUS_JAR = Path(sys.prefix) / 'share/pyjnius/pyjnius.jar'
-        if PYJNIUS_JAR.is_file():
+            PYJNIUS_JAR = sys.prefix + '/share/pyjnius/pyjnius.jar'
+        if Path(PYJNIUS_JAR).is_file():
             jnius_config.add_classpath(PYJNIUS_JAR)
         else:
             _logger.error('Unable to import scyjava: pyjnius JAR not found.')


### PR DESCRIPTION
This PR adds support to naively guess where `pyjnius.jar` and the jre might be upon trying to import scyjava. Note that this only works if these packages are installed in the default conda installation locations.

Further questions I have (since I am not very knowledgable about Python/conda:
* Is this enough to only worry about the conda defaults? Are there other default locations we could check?
* Will this also work in Windows / MacOS?