### PR TITLE
Rewrite to_java and to_python as a set of converter objects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.formatting.provider": "black"
+}

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -308,16 +308,12 @@ def _convertIterable(obj: collections.abc.Iterable):
 java_converters : typing.List[Converter] = []
 
 
-def add_java_converter(predicate: Callable[[Any], bool], converter: Callable[[Any], Any], priority: float):
+def add_java_converter(converter: Converter):
     """
     Adds a converter to the list used by to_java
-    :param predicate: A Callable identifying suitable data types for this converter
-    :param converter: A Callable able to convert a set of types
-    :priority: 
-
+    :param converter: A Converter going from python to java
     """
-    c = Converter(predicate, converter, priority)
-    _add_converter(c, java_converters)
+    _add_converter(converter, java_converters)
 
 
 def to_java(obj: Any) -> Any:
@@ -602,16 +598,12 @@ class JavaSet(JavaCollection, collections.abc.MutableSet):
 py_converters : typing.List[Converter] = []
 
 
-def add_py_converter(predicate: Callable[[Any], bool], converter: Callable[[Any], Any], priority: float):
+def add_py_converter(converter: Converter):
     """
     Adds a converter to the list used by to_python
-    :param predicate: A Callable identifying suitable data types for this converter
-    :param converter: A Callable able to convert a set of types
-    :priority: 
-
+    :param converter: A Converter from java to python
     """
-    c = Converter(predicate, converter, priority)
-    _add_converter(c, py_converters)
+    _add_converter(converter, py_converters)
 
 
 def to_python(data: Any, gentle: bool =False) -> Any:

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -776,6 +776,12 @@ def _stock_py_converters() -> typing.List:
             converter=JavaIterator,
             priority=Priority.NORMAL - 1
         ),
+        # JArray converter
+        Converter(
+            predicate=lambda obj: isinstance(obj, JArray),
+            converter=lambda obj:[to_python(o) for o in obj],
+            priority=Priority.VERY_LOW
+        ),
     ]
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -76,6 +76,23 @@ class TestConvert(unittest.TestCase):
         self.assertEqual(bi, pbi)
         self.assertEqual(str(bi), str(pbi))
 
+    def testFloat(self):
+        f = 5.
+        jf = to_java(f)
+        self.assertEqual(f, jf.floatValue())
+        pf = to_python(jf)
+        self.assertEqual(f, pf)
+        self.assertEqual(str(f), str(pf))
+
+    def testDouble(self):
+        Float = jimport('java.lang.Float')
+        d = Float.MAX_VALUE * 2
+        jd = to_java(d)
+        self.assertEqual(d, jd.doubleValue())
+        pd = to_python(jd)
+        self.assertEqual(d, pd)
+        self.assertEqual(str(d), str(pd))
+
     def testString(self):
         s = 'Hello world!'
         js = to_java(s)
@@ -206,6 +223,25 @@ class TestConvert(unittest.TestCase):
         assert len(pdict['set']) == 3
         assert type(pdict['object']) == Object
         self.assertEqual(pdict['foo'], 'bar')
+
+
+    def test_conversion_priority(self):
+        # Add a converter prioritized over the default converter
+        String = jimport('java.lang.String')
+        invader = 'Not Hello World'
+
+        from scyjava import add_java_converter
+        add_java_converter(
+            predicate=lambda obj: isinstance(obj, str),
+            converter=lambda obj: String(invader.encode('utf-8'), 'utf-8'),
+            priority=100
+        )
+
+        # Ensure that the conversion uses our new converter
+        s = 'Hello world!'
+        js = to_java(s)
+        for e, a in zip(invader, js.toCharArray()):
+            self.assertEqual(e, a)
 
 
 if __name__ == '__main__':

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,7 @@
 import unittest
-from scyjava import Converter, config, jclass, jimport, to_java, to_python
+
+from jpype import JArray, JInt, JLong
+from scyjava import Converter, config, jclass, jimport, start_jvm, to_java, to_python
 
 config.endpoints.append('org.scijava:scijava-table')
 config.add_option('-Djava.awt.headless=true')
@@ -123,6 +125,14 @@ class TestConvert(unittest.TestCase):
         ps = to_python(js)
         self.assertEqual(s, ps)
         self.assertEqual(str(s), str(ps))
+
+    def testArray(self):
+        start_jvm()
+        arr = JArray(JInt)(4)
+        for i in range(len(arr)):
+            arr[i] = to_java(i)
+        py_arr = to_python(arr)
+        assert py_arr == [0, 1, 2, 3]
 
     def testDict(self):
         d = {

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,5 @@
 import unittest
-from scyjava import config, jclass, jimport, to_java, to_python
+from scyjava import Converter, config, jclass, jimport, to_java, to_python
 
 config.endpoints.append('org.scijava:scijava-table')
 config.add_option('-Djava.awt.headless=true')
@@ -232,9 +232,11 @@ class TestConvert(unittest.TestCase):
 
         from scyjava import add_java_converter
         add_java_converter(
-            predicate=lambda obj: isinstance(obj, str),
-            converter=lambda obj: String(invader.encode('utf-8'), 'utf-8'),
-            priority=100
+            Converter(
+                predicate=lambda obj: isinstance(obj, str),
+                converter=lambda obj: String(invader.encode('utf-8'), 'utf-8'),
+                priority=100
+            )
         )
 
         # Ensure that the conversion uses our new converter


### PR DESCRIPTION
This PR seeks to do away with the confusing case logic of the `to_java` and `to_python` functions. Towards this effort, we introduce `Converter`:
```python
class Converter(NamedTuple):
    predicate: Callable[[Any], bool]
    converter: Callable[[Any], Any]
    priority: float = Priority.NORMAL
```
We then consolidate a number of these `Converter`s into two maps: one holds all `Converter`s going from Java to Python, and the other holds all `Converter`s going from Python to Java.

This reduces `to_java` to:
```python
def to_java(obj: Any) -> Any:
    """
    docstring omitted
    """
    start_jvm()
    return _convert(obj, java_converters)
```
where
```python
def _convert(obj: Any, converters: typing.List[Converter]) -> Any:
    suitable_converters = filter(lambda c: c.predicate(obj), converters)
    prioritized = max(suitable_converters, key = lambda c: c.priority)
    return prioritized.converter(obj)
```
`to_python` is similarly reduced to a call to `_convert` with `py_converters`

The `Converter`s lists are exposed as global variables; this is intended to allow users of ScyJava (namely PyImageJ, and likely napari-imagej) to add `Converter`s. By using high priority, this should allow those projects to also overwrite the `Converter`s of parent projects.

As of this writing, all commits build with passing tests.