### PR TITLE
Rewrite jimport as a LRU cache

### DIFF
--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -1,5 +1,6 @@
 import atexit
 import collections.abc
+from functools import lru_cache
 import traceback
 from typing import Any, Callable, NamedTuple
 import typing
@@ -302,6 +303,7 @@ def jclass(data):
     raise TypeError('Cannot glean class from data of type: ' + str(type(data)))
 
 
+@lru_cache
 def jimport(class_name):
     """
     Import a class from Java to Python.

--- a/scyjava/__init__.py
+++ b/scyjava/__init__.py
@@ -303,7 +303,7 @@ def jclass(data):
     raise TypeError('Cannot glean class from data of type: ' + str(type(data)))
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def jimport(class_name):
     """
     Import a class from Java to Python.


### PR DESCRIPTION
This should speed up the return for repeated imports.

Suggested by @ctrueden on Gitter.