### PR TITLE
Add support for JByte -> int conversion

### DIFF
--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -17,6 +17,7 @@ from typing import Dict
 from jpype.types import (
     JArray,
     JBoolean,
+    JByte,
     JChar,
     JDouble,
     JFloat,
@@ -839,7 +840,7 @@ def _stock_py_converters() -> typing.List:
         ),
         # JInt/JLong/JShort converter
         Converter(
-            predicate=lambda obj: isinstance(obj, (JInt, JLong, JShort)),
+            predicate=lambda obj: isinstance(obj, (JByte, JInt, JLong, JShort)),
             converter=int,
             priority=Priority.NORMAL + 1,
         ),

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,4 +1,4 @@
-from jpype import JArray, JInt
+from jpype import JArray, JByte, JInt
 
 from scyjava import Converter, config, jclass, jimport, start_jvm, to_java, to_python
 
@@ -42,6 +42,15 @@ class TestConvert(object):
         pf = to_python(jf)
         assert not pf
         assert "False" == str(pf)
+
+    def testByte(self):
+        # NB we can't (yet) convert TO Bytes, since there is not (yet)
+        # a great type to convert FROM. We convert python ints to Integers
+        i = 5
+        ji = JByte(i)
+        pi = to_python(ji)
+        assert i == pi
+        assert str(i) == str(pi)
 
     def testInteger(self):
         i = 5


### PR DESCRIPTION
This PR adds converter support for JPype's `JByte`s, converting them into python `int`s.

Note that we do **not** introduce any conversion *to* `JByte`s. This decision was intentional as there isn't a great python type; the only type I can think of that is similar is `int`, and I don't think we should be converting `int`s to any byte-like class.

