### PR TITLE
Add hints mechanism for scyjava converters

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -3,4 +3,9 @@
 dir=$(dirname "$0")
 cd "$dir/.."
 
-python -m pytest tests/ -p no:faulthandler $@
+if [ $# -gt 0 ]
+then
+  python -m pytest -p no:faulthandler $@
+else
+  python -m pytest -p no:faulthandler tests/
+fi

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -23,7 +23,7 @@ dependencies:
   # Project dependencies
   - jpype1 >= 1.3.0
   - jgo
-  - openjdk
+  - openjdk >= 8, < 12
   # Test dependencies
   - numpy
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   # Project dependencies
   - jpype1 >= 1.3.0
   - jgo
-  - openjdk=8
+  - openjdk >= 8
   # Project from source
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scyjava"
-version = "1.7.1.dev0"
+version = "1.8.0.dev0"
 description = "Supercharged Java access from Python"
 license = {text = "The Unlicense"}
 authors = [{name = "SciJava developers", email = "ctrueden@wisc.edu"}]

--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -102,6 +102,7 @@ from scyjava._java import (  # noqa: F401
     jarray,
     jclass,
     jimport,
+    jinstance,
     jstacktrace,
     jvm_started,
     jvm_version,

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -3,6 +3,7 @@ The scyjava conversion subsystem, and built-in conversion functions.
 """
 
 import collections
+import math
 from pathlib import Path
 from typing import Any, Callable, List, NamedTuple
 
@@ -162,13 +163,21 @@ def _stock_java_converters() -> List[Converter]:
         # float -> java.lang.Float
         Converter(
             predicate=lambda obj: isinstance(obj, float)
-            and _jc.Float.MIN_VALUE <= obj <= _jc.Float.MAX_VALUE,
+            and (
+                math.isinf(obj)
+                or math.isnan(obj)
+                or -_jc.Float.MAX_VALUE <= obj <= _jc.Float.MAX_VALUE
+            ),
             converter=_jc.Float,
         ),
         # float -> java.lang.Double
         Converter(
             predicate=lambda obj: isinstance(obj, float)
-            and _jc.Double.MAX_VALUE <= obj <= _jc.Double.MAX_VALUE,
+            and (
+                math.isinf(obj)
+                or math.isnan(obj)
+                or -_jc.Double.MAX_VALUE <= obj <= _jc.Double.MAX_VALUE
+            ),
             converter=_jc.Double,
             priority=Priority.NORMAL - 1,
         ),

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -163,15 +163,33 @@ def _stock_java_converters() -> List[Converter]:
             predicate=lambda obj: isinstance(obj, bool),
             converter=_jc.Boolean,
         ),
+        # int -> java.lang.Byte
+        Converter(
+            predicate=lambda obj, **hints: isinstance(obj, int)
+            and ("type" in hints and hints["type"] in ("b", "byte", "Byte"))
+            and _jc.Byte.MIN_VALUE <= obj <= _jc.Byte.MAX_VALUE,
+            converter=_jc.Byte,
+            priority=Priority.HIGH,
+        ),
+        # int -> java.lang.Short
+        Converter(
+            predicate=lambda obj, **hints: isinstance(obj, int)
+            and ("type" in hints and hints["type"] in ("s", "short", "Short"))
+            and _jc.Short.MIN_VALUE <= obj <= _jc.Short.MAX_VALUE,
+            converter=_jc.Short,
+            priority=Priority.HIGH,
+        ),
         # int -> java.lang.Integer
         Converter(
-            predicate=lambda obj: isinstance(obj, int)
+            predicate=lambda obj, **hints: isinstance(obj, int)
+            and ("type" not in hints or hints["type"] in ("i", "int", "Integer"))
             and _jc.Integer.MIN_VALUE <= obj <= _jc.Integer.MAX_VALUE,
             converter=_jc.Integer,
         ),
         # int -> java.lang.Long
         Converter(
-            predicate=lambda obj: isinstance(obj, int)
+            predicate=lambda obj, **hints: isinstance(obj, int)
+            and ("type" not in hints or hints["type"] in ("j", "l", "long", "Long"))
             and _jc.Long.MIN_VALUE <= obj <= _jc.Long.MAX_VALUE,
             converter=_jc.Long,
             priority=Priority.NORMAL - 1,
@@ -184,7 +202,8 @@ def _stock_java_converters() -> List[Converter]:
         ),
         # float -> java.lang.Float
         Converter(
-            predicate=lambda obj: isinstance(obj, float)
+            predicate=lambda obj, **hints: isinstance(obj, float)
+            and ("type" not in hints or hints["type"] in ("f", "float", "Float"))
             and (
                 math.isinf(obj)
                 or math.isnan(obj)
@@ -194,7 +213,8 @@ def _stock_java_converters() -> List[Converter]:
         ),
         # float -> java.lang.Double
         Converter(
-            predicate=lambda obj: isinstance(obj, float)
+            predicate=lambda obj, **hints: isinstance(obj, float)
+            and ("type" not in hints or hints["type"] in ("d", "double", "Double"))
             and (
                 math.isinf(obj)
                 or math.isnan(obj)

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, List, NamedTuple
 
 from jpype import JArray, JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 
-from ._java import JavaClasses, isjava, jclass, jimport, start_jvm
+from ._java import JavaClasses, isjava, jclass, jimport, jinstance, start_jvm
 
 
 # NB: We cannot use org.scijava.priority.Priority or other Java-side class
@@ -681,7 +681,7 @@ def _import_numpy(required=True):
 def _is_table(obj: Any) -> bool:
     """Check if obj is a table."""
     try:
-        return isinstance(obj, jimport("org.scijava.table.Table"))
+        return jinstance(obj, "org.scijava.table.Table")
     except BaseException:
         # No worries if scijava-table is not available.
         pass

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -79,7 +79,7 @@ java_converters: List[Converter] = []
 
 def add_java_converter(converter: Converter):
     """
-    Adds a converter to the list used by to_java
+    Add a converter to the list used by to_java.
     :param converter: A Converter going from python to java
     """
     java_converters.append(converter)
@@ -108,10 +108,10 @@ def to_java(obj: Any) -> Any:
 
 def _stock_java_converters() -> List[Converter]:
     """
-    Returns all python-to-java converters supported out of the box!
-    This should only be called after the JVM has been started!
+    Construct the Python-to-Java converters supported out of the box.
     :returns: A list of Converters
     """
+    start_jvm()
     return [
         # Other (Exceptional) converter
         Converter(
@@ -390,7 +390,7 @@ py_converters: List[Converter] = []
 
 def add_py_converter(converter: Converter):
     """
-    Adds a converter to the list used by to_python
+    Add a converter to the list used by to_python.
     :param converter: A Converter from java to python
     """
     py_converters.append(converter)
@@ -430,10 +430,10 @@ def to_python(data: Any, gentle: bool = False) -> Any:
 
 def _stock_py_converters() -> List:
     """
-    Returns all java-to-python converters supported out of the box!
-    This should only be called after the JVM has been started!
+    Construct the Java-to-Python converters supported out of the box.
     :returns: A list of Converters
     """
+    start_jvm()
 
     converters = [
         # Other (Exceptional) converter

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -566,7 +566,7 @@ def _stock_py_converters() -> typing.List:
         ),
     ]
 
-    if _import_numpy():
+    if _import_numpy(required=False):
         # primitive array -> numpy.ndarray
         converters.append(
             Converter(
@@ -575,7 +575,7 @@ def _stock_py_converters() -> typing.List:
             )
         )
 
-    if _import_pandas():
+    if _import_pandas(required=False):
         # org.scijava.table.Table -> pandas.DataFrame
         converters.append(
             Converter(
@@ -662,15 +662,16 @@ def _jarray_shape(jarr):
     return shape
 
 
-def _import_numpy():
+def _import_numpy(required=True):
     try:
         import numpy as np
 
         return np
     except ImportError as e:
-        msg = "The NumPy library is missing (https://numpy.org/). "
-        msg += "Please install it before using this function."
-        raise RuntimeError(msg) from e
+        if required:
+            msg = "The NumPy library is missing (https://numpy.org/). "
+            msg += "Please install it before using this function."
+            raise RuntimeError(msg) from e
 
 
 ######################################
@@ -696,15 +697,16 @@ def _convert_table(obj: Any):
         pass
 
 
-def _import_pandas():
+def _import_pandas(required=True):
     try:
         import pandas as pd
 
         return pd
     except ImportError as e:
-        msg = "The Pandas library is missing (http://pandas.pydata.org/). "
-        msg += "Please install it before using this function."
-        raise RuntimeError(msg) from e
+        if required:
+            msg = "The Pandas library is missing (http://pandas.pydata.org/). "
+            msg += "Please install it before using this function."
+            raise RuntimeError(msg) from e
 
 
 def _table_to_pandas(table):

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -3,9 +3,8 @@ The scyjava conversion subsystem, and built-in conversion functions.
 """
 
 import collections
-import typing
 from pathlib import Path
-from typing import Any, Callable, NamedTuple
+from typing import Any, Callable, List, NamedTuple
 
 from jpype import JArray, JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 
@@ -33,7 +32,7 @@ class Converter(NamedTuple):
     priority: float = Priority.NORMAL
 
 
-def _convert(obj: Any, converters: typing.List[Converter]) -> Any:
+def _convert(obj: Any, converters: List[Converter]) -> Any:
     suitable_converters = filter(lambda c: c.predicate(obj), converters)
     prioritized = max(suitable_converters, key=lambda c: c.priority)
     return prioritized.converter(obj)
@@ -74,7 +73,7 @@ def _convertIterable(obj: collections.abc.Iterable):
     return jlist
 
 
-java_converters: typing.List[Converter] = []
+java_converters: List[Converter] = []
 
 
 def add_java_converter(converter: Converter):
@@ -106,7 +105,7 @@ def to_java(obj: Any) -> Any:
     return _convert(obj, java_converters)
 
 
-def _stock_java_converters() -> typing.List[Converter]:
+def _stock_java_converters() -> List[Converter]:
     """
     Returns all python-to-java converters supported out of the box!
     This should only be called after the JVM has been started!
@@ -377,7 +376,7 @@ class JavaSet(JavaCollection, collections.abc.MutableSet):
         return "{" + ", ".join(_jstr(v) for v in self) + "}"
 
 
-py_converters: typing.List[Converter] = []
+py_converters: List[Converter] = []
 
 
 def add_py_converter(converter: Converter):
@@ -420,7 +419,7 @@ def to_python(data: Any, gentle: bool = False) -> Any:
         raise exc
 
 
-def _stock_py_converters() -> typing.List:
+def _stock_py_converters() -> List:
     """
     Returns all java-to-python converters supported out of the box!
     This should only be called after the JVM has been started!

--- a/src/scyjava/_java.py
+++ b/src/scyjava/_java.py
@@ -384,6 +384,20 @@ def jclass(data):
     raise TypeError("Cannot glean class from data of type: " + str(type(data)))
 
 
+def jinstance(obj, jtype):
+    """
+    Test if the given object is an instance of a particular Java type.
+
+    :param obj: The object to check.
+    :param jtype: The Java type, as either a jimported class or as a string.
+    :returns: True iff the object is an instance of that Java type.
+    """
+    if isinstance(jtype, str):
+        jtype = jimport(jtype)
+
+    return isinstance(obj, jtype)
+
+
 def jstacktrace(exc):
     """
     Extract the Java-side stack trace from a Java exception.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -3,7 +3,16 @@ from pathlib import Path
 
 from jpype import JByte
 
-from scyjava import Converter, config, jarray, jclass, jimport, to_java, to_python
+from scyjava import (
+    Converter,
+    config,
+    jarray,
+    jclass,
+    jimport,
+    jinstance,
+    to_java,
+    to_python,
+)
 
 config.endpoints.append("org.scijava:scijava-table")
 config.add_option("-Djava.awt.headless=true")
@@ -182,7 +191,7 @@ class TestConvert(object):
     def testPath(self):
         py_path = Path(getcwd())
         j_path = to_java(py_path)
-        assert isinstance(j_path, jimport("java.nio.file.Path"))
+        assert jinstance(j_path, "java.nio.file.Path")
         assert str(j_path) == str(py_path)
 
         actual = to_python(j_path)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,8 +2,6 @@ import math
 from os import getcwd
 from pathlib import Path
 
-from jpype import JByte
-
 from scyjava import (
     Converter,
     config,
@@ -60,13 +58,22 @@ class TestConvert(object):
         assert pfalse is False
 
     def testByte(self):
-        # NB we can't (yet) convert TO Bytes, since there is not (yet)
-        # a great type to convert FROM. We convert python ints to Integers
-        i = 5
-        ji = JByte(i)
-        pi = to_python(ji)
-        assert i == pi
-        assert str(i) == str(pi)
+        obyte = 5
+        jbyte = to_java(obyte, type="b")
+        assert jinstance(jbyte, "java.lang.Byte")
+        assert obyte == jbyte.byteValue()
+        pbyte = to_python(jbyte)
+        assert isinstance(pbyte, int)
+        assert obyte == pbyte
+
+    def testShort(self):
+        oshort = 5
+        jshort = to_java(oshort, type="s")
+        assert jinstance(jshort, "java.lang.Short")
+        assert oshort == jshort.shortValue()
+        pshort = to_python(jshort)
+        assert isinstance(pshort, int)
+        assert oshort == pshort
 
     def testInteger(self):
         oint = 5

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,3 +1,4 @@
+import math
 from os import getcwd
 from pathlib import Path
 
@@ -44,16 +45,19 @@ class TestConvert(object):
         assert "java.util.Map" == jclass("java.util.Map").getName()
 
     def testBoolean(self):
-        jt = to_java(True)
-        assert jt.booleanValue()
-        pt = to_python(jt)
-        assert pt
-        assert "True" == str(pt)
-        jf = to_java(False)
-        assert not jf.booleanValue()
-        pf = to_python(jf)
-        assert not pf
-        assert "False" == str(pf)
+        jtrue = to_java(True)
+        assert jinstance(jtrue, "java.lang.Boolean")
+        assert jtrue.booleanValue() is True
+        ptrue = to_python(jtrue)
+        assert isinstance(ptrue, bool)
+        assert ptrue is True
+
+        jfalse = to_java(False)
+        assert jinstance(jfalse, "java.lang.Boolean")
+        assert jfalse.booleanValue() is False
+        pfalse = to_python(jfalse)
+        assert isinstance(pfalse, bool)
+        assert pfalse is False
 
     def testByte(self):
         # NB we can't (yet) convert TO Bytes, since there is not (yet)
@@ -65,63 +69,90 @@ class TestConvert(object):
         assert str(i) == str(pi)
 
     def testInteger(self):
-        i = 5
-        ji = to_java(i)
-        assert i == ji.intValue()
-        pi = to_python(ji)
-        assert i == pi
-        assert str(i) == str(pi)
+        oint = 5
+        jint = to_java(oint)
+        assert jinstance(jint, "java.lang.Integer")
+        assert oint == jint.intValue()
+        pint = to_python(jint)
+        assert isinstance(pint, int)
+        assert oint == pint
 
     def testLong(self):
-        long = 4000000001
-        jlong = to_java(long)
-        assert long == jlong.longValue()
+        olong = 4000000001
+        jlong = to_java(olong)
+        assert jinstance(jlong, "java.lang.Long")
+        assert olong == jlong.longValue()
         plong = to_python(jlong)
-        assert long == plong
-        assert str(long) == str(plong)
+        assert isinstance(plong, int)
+        assert olong == plong
 
     def testBigInteger(self):
-        bi = 9879999999999999789
-        jbi = to_java(bi)
-        assert bi == int(str(jbi.toString()))
+        obi = 9879999999999999789
+        jbi = to_java(obi)
+        assert jinstance(jbi, "java.math.BigInteger")
+        assert str(obi) == str(jbi.toString())
         pbi = to_python(jbi)
-        assert bi == pbi
-        assert str(bi) == str(pbi)
+        assert isinstance(pbi, int)
+        assert obi == pbi
 
     def testFloat(self):
-        f = 5.0
-        jf = to_java(f)
-        assert f == jf.floatValue()
-        pf = to_python(jf)
-        assert f == pf
-        assert str(f) == str(pf)
+        ofloat = 5.0
+        jfloat = to_java(ofloat)
+        assert jinstance(jfloat, "java.lang.Float")
+        assert ofloat == jfloat.floatValue()
+        pfloat = to_python(jfloat)
+        assert isinstance(pfloat, float)
+        assert ofloat == pfloat
 
     def testDouble(self):
-        Float = jimport("java.lang.Float")
-        d = Float.MAX_VALUE * 2
-        jd = to_java(d)
-        assert d == jd.doubleValue()
-        pd = to_python(jd)
-        assert d == pd
-        assert str(d) == str(pd)
+        odouble = 4.56e123
+        jdouble = to_java(odouble)
+        assert jinstance(jdouble, "java.lang.Double")
+        assert odouble == jdouble.doubleValue()
+        pdouble = to_python(jdouble)
+        assert isinstance(pdouble, float)
+        assert odouble == pdouble
+
+    def testInf(self):
+        jinf = to_java(math.inf)
+        assert jinstance(jinf, "java.lang.Float")
+        assert math.inf == jinf.floatValue()
+        pinf = to_python(jinf)
+        assert isinstance(pinf, float)
+        assert math.inf == pinf
+
+        jninf = to_java(-math.inf)
+        assert jinstance(jninf, "java.lang.Float")
+        assert -math.inf == jninf.floatValue()
+        pninf = to_python(jninf)
+        assert isinstance(pninf, float)
+        assert -math.inf == pninf
+
+    def testNaN(self):
+        jnan = to_java(math.nan)
+        assert jinstance(jnan, "java.lang.Float")
+        assert math.isnan(jnan.floatValue())
+        pnan = to_python(jnan)
+        assert isinstance(pnan, float)
+        assert math.isnan(pnan)
 
     def testString(self):
-        s = "Hello world!"
-        js = to_java(s)
-        for e, a in zip(s, js.toCharArray()):
+        ostring = "Hello world!"
+        jstring = to_java(ostring)
+        assert jinstance(jstring, "java.lang.String")
+        for e, a in zip(ostring, jstring.toCharArray()):
             assert e == a
-        ps = to_python(js)
-        assert s == ps
-        assert str(s) == str(ps)
+        pstring = to_python(jstring)
+        assert ostring == pstring
 
     def testList(self):
-        list = "The quick brown fox jumps over the lazy dogs".split()
-        jlist = to_java(list)
-        for e, a in zip(list, jlist):
+        olist = "The quick brown fox jumps over the lazy dogs".split()
+        jlist = to_java(olist)
+        for e, a in zip(olist, jlist):
             assert e == to_python(a)
         plist = to_python(jlist)
-        assert list == plist
-        assert str(list) == str(plist)
+        assert olist == plist
+        assert str(olist) == str(plist)
         assert plist[1] == "quick"
         plist[7] = "silly"
         assert "The quick brown fox jumps over the silly dogs" == " ".join(plist)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 
-from scyjava import config, jimport, to_java
+from scyjava import config, jinstance, to_java
 
 config.endpoints.append("org.scijava:scijava-table")
 config.add_option("-Djava.awt.headless=true")
@@ -28,8 +28,7 @@ class TestPandas(object):
         table = to_java(df)
 
         assert_same_table(table, df)
-        DefaultFloatTable = jimport("org.scijava.table.DefaultFloatTable")
-        assert isinstance(table, DefaultFloatTable)
+        assert jinstance(table, "org.scijava.table.DefaultFloatTable")
 
         # Int table.
         columns = ["header1", "header2", "header3", "header4", "header5"]
@@ -40,8 +39,7 @@ class TestPandas(object):
         table = to_java(df)
 
         assert_same_table(table, df)
-        DefaultIntTable = jimport("org.scijava.table.DefaultIntTable")
-        assert isinstance(table, DefaultIntTable)
+        assert jinstance(table, "org.scijava.table.DefaultIntTable")
 
         # Bool table.
         columns = ["header1", "header2", "header3", "header4", "header5"]
@@ -51,8 +49,7 @@ class TestPandas(object):
         table = to_java(df)
 
         assert_same_table(table, df)
-        DefaultBoolTable = jimport("org.scijava.table.DefaultBoolTable")
-        assert isinstance(table, DefaultBoolTable)
+        assert jinstance(table, "org.scijava.table.DefaultBoolTable")
 
         # Mixed table.
         columns = ["header1", "header2", "header3", "header4", "header5"]
@@ -71,5 +68,4 @@ class TestPandas(object):
 
         # Table types cannot be the same here, unless we want to cast.
         # assert_same_table(table, df)
-        DefaultGenericTable = jimport("org.scijava.table.DefaultGenericTable")
-        assert isinstance(table, DefaultGenericTable)
+        assert jinstance(table, "org.scijava.table.DefaultGenericTable")


### PR DESCRIPTION
### Intro

This PR adds `**kwargs` to `scyjava`'s converter mechanism. This change is necessary to support the `to_xarray()` changes in the pipe for `pyimagej` (see https://github.com/imagej/pyimagej/pull/231) for more details.

### Features

- Adds `**kwarg**` support -- enables `ij.py.to_java(data, dim_order=["x", "y", "z"])`
- Inspects signature of the identified converter. `inspect.signature` doesn't work on Java objects. Here we just drop the `kwargs`. I think this is better than trying to add signature detection for Java methods.