### PR TITLE
Add an object for SciJava scripting with Python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,18 +84,27 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
+      - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if dev-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('dev-environment.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           # Create env with dev packages
           auto-update-conda: true
           python-version: 3.9
+          miniforge-variant: Mambaforge
           environment-file: dev-environment.yml
           # Activate scyjava-dev environment
           activate-environment: scyjava-dev
           auto-activate-base: false
           # Use mamba for faster setup
           use-mamba: true
-          mamba-version: "*"
       - name: Test scyjava
         run: |
           bin/test.sh --cov-report=xml --cov=.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ FUNCTIONS
         Add a converter to the list used by to_python.
         :param converter: A Converter from java to python
 
+    enable_python_scripting(context)
+        Adds a Python script runner object to the ObjectService of the given
+        SciJava context. Intended for use in conjunction with
+        'org.scijava:scripting-python'.
+
+        :param context: The org.scijava.Context containing the ObjectService
+            where the PythonScriptRunner should be injected.
+
     get_version(java_class_or_python_package) -> str
         Return the version of a Java class or Python package.
 

--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -112,6 +112,7 @@ from scyjava._java import (  # noqa: F401
     when_jvm_starts,
     when_jvm_stops,
 )
+from scyjava._script import enable_python_scripting  # noqa: F401
 from scyjava._versions import (  # noqa: F401
     compare_version,
     get_version,

--- a/src/scyjava/_java.py
+++ b/src/scyjava/_java.py
@@ -204,7 +204,6 @@ def start_jvm(options=None) -> None:
         or not os.environ["JAVA_HOME"]
         or not os.path.isdir(os.environ["JAVA_HOME"])
     ):
-
         _logger.debug("JAVA_HOME not set. Will try to infer it from sys.path.")
 
         libjvm_win = Path("Library") / "jre" / "bin" / "server" / "jvm.dll"

--- a/src/scyjava/_script.py
+++ b/src/scyjava/_script.py
@@ -75,7 +75,11 @@ def enable_python_scripting(context):
 
                 block = ast.parse(str(arg.script), mode="exec")
                 last = None
-                if len(block.body) > 0 and hasattr(block.body[-1], "value"):
+                if (
+                    len(block.body) > 0
+                    and hasattr(block.body[-1], "value")
+                    and not isinstance(block.body[-1], ast.Assign)
+                ):
                     # Last statement of the script looks like an expression. Evaluate!
                     last = ast.Expression(block.body.pop().value)
 

--- a/src/scyjava/_script.py
+++ b/src/scyjava/_script.py
@@ -1,0 +1,107 @@
+"""
+Logic for making Python available to Java as a SciJava scripting language.
+
+For the Java side of this functionality, see
+https://github.com/scijava/scripting-python.
+"""
+
+import ast
+import sys
+import threading
+import traceback
+
+from jpype import JImplements, JOverride
+
+from ._convert import to_java
+from ._java import jimport
+
+
+def enable_python_scripting(context):
+    """
+    Adds a Python script runner object to the ObjectService of the given
+    SciJava context. Intended for use in conjunction with
+    'org.scijava:scripting-python'.
+
+    :param context: The org.scijava.Context containing the ObjectService
+        where the PythonScriptRunner should be injected.
+    """
+    ObjectService = jimport("org.scijava.object.ObjectService")
+
+    class ScriptContextWriter:
+        def __init__(self, std):
+            self._std_default = std
+            self._thread_to_context = {}
+
+        def addScriptContext(self, thread, scriptContext):
+            self._thread_to_context[thread] = scriptContext
+
+        def removeScriptContext(self, thread):
+            if thread in self._thread_to_context:
+                del self._thread_to_context[thread]
+
+        def flush(self):
+            self._std_default.flush()
+
+        def write(self, s):
+            if threading.currentThread() in self._thread_to_context:
+                self._thread_to_context[threading.currentThread()].getWriter().write(
+                    to_java(s)
+                )
+            else:
+                self._std_default.write(s)
+
+    # Q: Is there a better way to manage stdout in conjunction with the script runner?
+    stdoutContextWriter = ScriptContextWriter(sys.stdout)
+    sys.stdout = stdoutContextWriter
+
+    @JImplements("java.util.function.Function")
+    class PythonScriptRunner:
+        @JOverride
+        def apply(self, arg):
+            # Copy script bindings/vars into script locals.
+            script_locals = {}
+            for key in arg.vars.keys():
+                script_locals[key] = arg.vars[key]
+
+            stdoutContextWriter.addScriptContext(
+                threading.currentThread(), arg.scriptContext
+            )
+
+            return_value = None
+            try:
+                # NB: Execute the block, except for the last statement,
+                # which we evaluate instead to get its return value.
+                # Credit: https://stackoverflow.com/a/39381428/1207769
+
+                block = ast.parse(str(arg.script), mode="exec")
+                last = None
+                if len(block.body) > 0 and hasattr(block.body[-1], "value"):
+                    # Last statement of the script looks like an expression. Evaluate!
+                    last = ast.Expression(block.body.pop().value)
+
+                _globals = {}
+                exec(compile(block, "<string>", mode="exec"), _globals, script_locals)
+                if last is not None:
+                    return_value = eval(
+                        compile(last, "<string>", mode="eval"), _globals, script_locals
+                    )
+            except Exception:
+                error_writer = arg.scriptContext.getErrorWriter()
+                if error_writer is not None:
+                    error_writer.write(to_java(traceback.format_exc()))
+
+            stdoutContextWriter.removeScriptContext(threading.currentThread())
+
+            # Copy script locals back into script bindings/vars.
+            for key in script_locals.keys():
+                try:
+                    arg.vars[key] = to_java(script_locals[key])
+                except Exception:
+                    error_writer = arg.scriptContext.getErrorWriter()
+                    if error_writer is not None:
+                        error_writer.write(to_java(traceback.format_exc()))
+
+            return to_java(return_value)
+
+    objectService = context.service(ObjectService)
+    objectService.addObject(PythonScriptRunner(), "PythonScriptRunner")

--- a/src/scyjava/_script.py
+++ b/src/scyjava/_script.py
@@ -54,6 +54,15 @@ def enable_python_scripting(context):
     stdoutContextWriter = ScriptContextWriter(sys.stdout)
     sys.stdout = stdoutContextWriter
 
+    @JImplements("java.util.function.Supplier")
+    class PythonObjectSupplier:
+        def __init__(self, obj):
+            self.obj = obj
+
+        @JOverride
+        def get(self):
+            return self.obj
+
     @JImplements("java.util.function.Function")
     class PythonScriptRunner:
         @JOverride
@@ -101,9 +110,10 @@ def enable_python_scripting(context):
                 try:
                     arg.vars[key] = to_java(script_locals[key])
                 except Exception:
-                    error_writer = arg.scriptContext.getErrorWriter()
-                    if error_writer is not None:
-                        error_writer.write(to_java(traceback.format_exc()))
+                    arg.vars[key] = PythonObjectSupplier(script_locals[key])
+                    # error_writer = arg.scriptContext.getErrorWriter()
+                    # if error_writer is not None:
+                    #    error_writer.write(to_java(traceback.format_exc()))
 
             return to_java(return_value)
 


### PR DESCRIPTION
This is an update of @karlduderstadt's awesome work on imagej/pyimagej#159. The goal is to make it super easy to bootstrap the [`org.scijava:scripting-python` script language plugin](https://github.com/scijava/scripting-python). It will require a little bit of adjustment on the scripting-python side, since with this version of the work, the named `ScriptingPythonRunner` in the `ObjectService` is now a `java.util.function.Function` which expects to be handed an object with specific baked-in fields (`script`, `vars`, and `scriptContext`).

I am filing this a draft for now, because we need to test it before it can be merged. There will be corresponding PRs to scripting-python and pyimagej with same branch name `python-script-runner`; the idea will be to use them all locally together and see what explodes!