### PR TITLE
Avoid converting objects when not necessary

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -57,7 +57,7 @@ fi
 echo "
 import logging, sys, pytest, scyjava
 scyjava._logger.addHandler(logging.StreamHandler(sys.stderr))
-scyjava._logger.setLevel(logging.DEBUG)
+scyjava._logger.setLevel(logging.INFO)
 scyjava.config.set_verbose(2)
 result = pytest.main($argString)
 if result:

--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -174,10 +174,15 @@ def __getattr__(name):
 
 
 def _initialize_converters():
+    _logger.debug("Initializing type converters")
+
     for converter in _stock_java_converters():
         add_java_converter(converter)
+    _logger.debug("Java converters:{'\n-'.join(java_converters)}")
+
     for converter in _stock_py_converters():
         add_py_converter(converter)
+    _logger.debug("Python converters:{'\n-'.join(py_converters)}")
 
 
 when_jvm_starts(_initialize_converters)

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -4,6 +4,7 @@ The scyjava conversion subsystem, and built-in conversion functions.
 
 import collections
 import inspect
+import logging
 import math
 from bisect import insort
 from pathlib import Path
@@ -23,6 +24,8 @@ from ._java import (
     mode,
     start_jvm,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 # NB: We cannot use org.scijava.priority.Priority or other Java-side class
@@ -92,9 +95,14 @@ def _convert(obj: Any, converters: List[Converter], **hints: Dict) -> Any:
     # meaning lower-priority items appear earlier than higher-priority ones.
     # But we want to try the higher priority converters first, so we
     # need to iterate the given converters list starting at the end.
+    debug = hints.get("debug", False)
+    log = _logger.info if debug else _logger.debug
+    log(f"Converting object of type {type(obj)} with hints {hints}")
     for converter in reversed(converters):
         if converter.supports(obj, **hints):
+            log(f"- {converter} supports")
             return converter.convert(obj, **hints)
+        log(f"- {converter} does not support")
 
 
 # -- Python to Java --

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -343,6 +343,7 @@ class TestConvert(object):
         invader = "Not Hello World"
 
         bad_converter = Converter(
+            name=f"test_conversion_priority: str -> '{invader}'",
             predicate=lambda obj: isinstance(obj, str),
             converter=lambda obj: String(invader.encode("utf-8"), "utf-8"),
             priority=100,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -14,6 +14,7 @@ from scyjava import (
     jclass,
     jimport,
     jinstance,
+    py_converters,
     to_java,
     to_python,
 )
@@ -355,3 +356,9 @@ class TestConvert(object):
             assert e == a
 
         java_converters.remove(bad_converter)
+
+    def test_converter_priority(self):
+        assert len(java_converters) > 0
+        assert sorted(java_converters) == java_converters
+        assert len(py_converters) > 0
+        assert sorted(py_converters) == py_converters


### PR DESCRIPTION
`to_python` and `to_java` assume that their arguments are in the other language. But, as described in imagej/napari-imagej#220, `Converter`s have to defensively program against arguments that are already in the desired language.

This PR does a sanity check on the argument to convert, ensuring that the argument to a `to_java` call is actually a python data structure, and that the argument to a `to_python` call is actually a java data structure. When the argument is not, this change will save us a bit of computation at the least, and save us from some errors in more severe cases.