### PR TITLE
Relax jpype1 version constrain

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -20,7 +20,7 @@ channels:
 dependencies:
   - python >= 3.8
   # Project dependencies
-  - jpype1 >= 1.3.0, <= 1.5.0
+  - jpype1 >= 1.3.0
   - jgo
   - openjdk >= 8, < 12
   # Test dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ channels:
 dependencies:
   - python >= 3.8
   # Project dependencies
-  - jpype1 >= 1.3.0, <= 1.5.0
+  - jpype1 >= 1.3.0
   - jgo
   - openjdk >= 8
   # Project from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 # NB: Keep this in sync with environment.yml AND dev-environment.yml!
 requires-python = ">=3.8"
 dependencies = [
-    "jpype1 >= 1.3.0, <= 1.5.0",
+    "jpype1 >= 1.3.0",
     "jgo",
 ]
 


### PR DESCRIPTION
With the [new release](https://github.com/jpype-project/jpype/releases/tag/v1.5.2) of `jpype1`, the JVM issue is fixed. So we can hopefully relax the upper bound of version constrain.