### PR TITLE
Test if function can read module into local namespace

### DIFF
--- a/tests/it/script_scope.py
+++ b/tests/it/script_scope.py
@@ -35,10 +35,11 @@ script = """
 import numpy as np
 
 def calculate_cbrt(age):
-    return round(age ** (1. / 3))
+    # check whether defined function can import module from global namespace
+    if round(age ** (1. / 3)) == round(np.cbrt(age)):
+        return round(age ** (1. /3))
 
 cbrt_age = calculate_cbrt(age)
-# cbrt_age = round(math.cbrt(age))
 f"The rounded cube root of my age is {cbrt_age}"
 """
 StringReader = scyjava.jimport("java.io.StringReader")


### PR DESCRIPTION
Pardon this, but I wanted to fix the test so that it would fail if the defined function isn't able to read an imported module in the global namespace.

We found that `math.cbrt()` was only implemented in Python 3.11, but we should still use some module import (I'm using `np.cbrt()` instead here because it goes back to numpy 1.10 - but feel free to use any you like).