### PR TITLE
feat: add option to autofetch-java with cjdk if available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,13 @@ jobs:
           '3.10',
           '3.12'
         ]
+        java-version: ['11']
+        include:
+          # one test without java to test cjdk fallback
+          - os: ubuntu-latest
+            python-version: '3.12'
+            java-version: ''
+
 
     steps:
     - uses: actions/checkout@v2
@@ -35,8 +42,9 @@ jobs:
         python-version: ${{matrix.python-version}}
 
     - uses: actions/setup-java@v3
+      if: matrix.java-version != ''
       with:
-        java-version: '11'
+        java-version: ${{matrix.java-version}}
         distribution: 'zulu'
         cache: 'maven'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,14 @@ jobs:
           macos-latest
         ]
         python-version: [
-          '3.8',
-          '3.10',
-          '3.12'
+          '3.9',
+          '3.13'
         ]
         java-version: ['11']
         include:
           # one test without java to test cjdk fallback
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.9'
             java-version: ''
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-cross-platform:
-    name: test ${{matrix.os}} - ${{matrix.python-version}}
+    name: test ${{matrix.os}} - ${{matrix.python-version}} - ${{matrix.java-version}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,7 +32,6 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.12'
             java-version: ''
-
 
     steps:
     - uses: actions/checkout@v2

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -73,7 +73,12 @@ then
 else
   argString=""
 fi
-if [ "$(uname -s)" = "Darwin" ]
+if ! java -version 2>&1 | grep -q '^openjdk version "\(1\.8\|9\|10\|11\|12\|13\|14\|15\|16\)\.'
+then
+  echo "Skipping jep tests due to unsupported Java version:"
+  java -version || true
+  jepCode=0
+elif [ "$(uname -s)" = "Darwin" ]
 then
   echo "Skipping jep tests on macOS due to flakiness"
   jepCode=0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -37,5 +37,6 @@ dependencies:
   # Project from source
   - pip
   - pip:
+    - cjdk
     - git+https://github.com/ninia/jep.git@cfca63f8b3398daa6d2685428660dc4b2bfab67d
     - -e .

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -18,7 +18,7 @@ name: scyjava-dev
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8
+  - python >= 3.9
   # Project dependencies
   - jpype1 >= 1.3.0
   - jgo

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ name: scyjava
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8
+  - python >= 3.9
   # Project dependencies
   - jpype1 >= 1.3.0
   - jgo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,12 @@ requires-python = ">=3.8"
 dependencies = [
     "jpype1 >= 1.3.0",
     "jgo",
+    "cjdk",
 ]
 
 [project.optional-dependencies]
 # NB: Keep this in sync with dev-environment.yml!
-cjdk = ["cjdk"]
 dev = [
-    "scyjava[cjdk]",
     "assertpy",
     "build",
     "jep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dependencies = [
 
 [project.optional-dependencies]
 # NB: Keep this in sync with dev-environment.yml!
+cjdk = ["cjdk"]
 dev = [
+    "scyjava[cjdk]",
     "assertpy",
     "build",
     "jep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=61.2"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "scyjava"
-version = "1.10.3.dev0"
+version = "1.11.0.dev0"
 description = "Supercharged Java access from Python"
-license = {text = "Unlicense"}
+license = "Unlicense"
 authors = [{name = "SciJava developers", email = "ctrueden@wisc.edu"}]
 readme = "README.md"
 keywords = ["java", "maven", "cross-language"]
@@ -16,11 +16,11 @@ classifiers = [
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: Unix",
     "Operating System :: MacOS",
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 # NB: Keep this in sync with environment.yml AND dev-environment.yml!
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "jpype1 >= 1.3.0",
     "jgo",

--- a/src/scyjava/_cjdk_fetch.py
+++ b/src/scyjava/_cjdk_fetch.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import jpype
 
@@ -118,7 +118,7 @@ def cjdk_fetch_maven(url: str = "", sha: str = "", raise_on_error: bool = True) 
         raise RuntimeError("Failed to find Maven executable in the downloaded package.")
 
 
-def _add_to_path(path: Path | str, front: bool = False) -> None:
+def _add_to_path(path: Union[Path, str], front: bool = False) -> None:
     """Add a path to the PATH environment variable.
 
     If front is True, the path is added to the front of the PATH.

--- a/src/scyjava/_cjdk_fetch.py
+++ b/src/scyjava/_cjdk_fetch.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+_DEFAULT_MAVEN_URL = "tgz+https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz"  # noqa: E501
+_DEFAULT_MAVEN_SHA = "a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b"  # noqa: E501
+_DEFAULT_JAVA_VENDOR = "zulu-jre"
+_DEFAULT_JAVA_VERSION = "11"
+
+
+def cjdk_fetch_java(
+    vendor: str = "", version: str = "", raise_on_error: bool = True
+) -> None:
+    """Fetch java using cjdk and add it to the PATH."""
+    try:
+        import cjdk
+    except ImportError as e:
+        if raise_on_error is True:
+            raise ImportError(
+                "No JVM found. Please install `cjdk` to use the fetch_java feature."
+            ) from e
+        _logger.info("cjdk is not installed. Skipping automatic fetching of java.")
+        return
+
+    if not vendor:
+        vendor = os.getenv("JAVA_VENDOR", _DEFAULT_JAVA_VENDOR)
+        version = os.getenv("JAVA_VERSION", _DEFAULT_JAVA_VERSION)
+
+    _logger.info(f"No JVM found, fetching {vendor}:{version} using cjdk...")
+    home = cjdk.java_home(vendor=vendor, version=version)
+    _add_to_path(str(home / "bin"))
+    os.environ["JAVA_HOME"] = str(home)
+
+
+def cjdk_fetch_maven(url: str = "", sha: str = "", raise_on_error: bool = True) -> None:
+    """Fetch Maven using cjdk and add it to the PATH."""
+    try:
+        import cjdk
+    except ImportError as e:
+        if raise_on_error is True:
+            raise ImportError(
+                "Please install `cjdk` to use the fetch_java feature."
+            ) from e
+        _logger.info("cjdk is not installed. Skipping automatic fetching of Maven.")
+        return
+
+    # if url was passed as an argument, or env_var, use it with provided sha
+    # otherwise, use default values for both
+    if url := url or os.getenv("MAVEN_URL", ""):
+        sha = sha or os.getenv("MAVEN_SHA", "")
+    else:
+        url = _DEFAULT_MAVEN_URL
+        sha = _DEFAULT_MAVEN_SHA
+
+    # fix urls to have proper prefix for cjdk
+    if url.startswith("http"):
+        if url.endswith(".tar.gz"):
+            url = url.replace("http", "tgz+http")
+        elif url.endswith(".zip"):
+            url = url.replace("http", "zip+http")
+
+    # determine sha type based on length (cjdk requires specifying sha type)
+    # assuming hex-encoded SHA, length should be 40, 64, or 128
+    kwargs = {}
+    if sha_len := len(sha):  # empty sha is fine... we just don't pass it
+        sha_lengths = {40: "sha1", 64: "sha256", 128: "sha512"}
+        if sha_len not in sha_lengths:
+            raise ValueError(
+                "MAVEN_SHA be a valid sha1, sha256, or sha512 hash."
+                f"Got invalid SHA length: {sha_len}. "
+            )
+        kwargs = {sha_lengths[sha_len]: sha}
+
+    maven_dir = cjdk.cache_package("Maven", url, **kwargs)
+    if maven_bin := next(maven_dir.rglob("apache-maven-*/**/mvn"), None):
+        _add_to_path(maven_bin.parent, front=True)
+    else:
+        raise RuntimeError("Failed to find Maven executable in the downloaded package.")
+
+
+def _add_to_path(path: Path | str, front: bool = False) -> None:
+    """Add a path to the PATH environment variable.
+
+    If front is True, the path is added to the front of the PATH.
+    By default, the path is added to the end of the PATH.
+    If the path is already in the PATH, it is not added again.
+    """
+
+    current_path = os.environ.get("PATH", "")
+    if (path := str(path)) in current_path:
+        return
+    new_path = [path, current_path] if front else [current_path, path]
+    os.environ["PATH"] = os.pathsep.join(new_path)

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -16,7 +16,6 @@ import jpype
 import jpype.config
 from jgo import jgo
 
-from scyjava._cjdk_fetch import ensure_jvm_available
 import scyjava.config
 from scyjava.config import Mode, mode
 
@@ -143,6 +142,8 @@ def start_jvm(options=None, *, fetch_java: bool | None = None) -> None:
     _logger.debug("Adding jars from endpoints {0}".format(endpoints))
 
     if fetch_java is not False:
+        from scyjava._cjdk_fetch import ensure_jvm_available
+
         ensure_jvm_available(raise_on_error=fetch_java is True)
 
     # get endpoints and add to JPype class path

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -6,7 +6,6 @@ import atexit
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 from functools import lru_cache
@@ -17,7 +16,7 @@ import jpype
 import jpype.config
 from jgo import jgo
 
-from scyjava._cjdk_fetch import cjdk_fetch_java, cjdk_fetch_maven
+from scyjava._cjdk_fetch import ensure_jvm_available
 import scyjava.config
 from scyjava.config import Mode, mode
 
@@ -120,10 +119,12 @@ def start_jvm(options=None, *, fetch_java: bool | None = None) -> None:
         List of options to pass to the JVM.
         For example: ['-Dfoo=bar', '-XX:+UnlockExperimentalVMOptions']
     :param fetch_java:
-        Whether to automatically fetch a JRE (and/or maven) using
+        Whether to automatically fetch a JRE (and maven) using
         [`cjdk`](https://github.com/cachedjdk/cjdk) if java and maven executables are
-        not found. Requires `cjdk` to be installed. See README for details.
+        not found. Requires `cjdk` to be installed, either manually, or via the
+        `scyjava[cjdk]` extra.
             - If `None` (default), then fetching will only occur if `cjdk` is available.
+              (A log info will be issued if `cjdk` is not available.)
             - If `True`, an exception will be raised if `cjdk` is not available.
             - If `False`, no attempt to import `cjdk` is be made.
     """
@@ -141,14 +142,11 @@ def start_jvm(options=None, *, fetch_java: bool | None = None) -> None:
     # use the logger to notify user that endpoints are being added
     _logger.debug("Adding jars from endpoints {0}".format(endpoints))
 
-    if fetch_java is not False and not is_jvm_available():
-        cjdk_fetch_java(raise_on_error=fetch_java is True)
+    if fetch_java is not False:
+        ensure_jvm_available(raise_on_error=fetch_java is True)
 
     # get endpoints and add to JPype class path
     if len(endpoints) > 0:
-        if not shutil.which("mvn") and fetch_java is not False:
-            cjdk_fetch_maven(raise_on_error=fetch_java is True)
-
         endpoints = endpoints[:1] + sorted(endpoints[1:])
         _logger.debug("Using endpoints %s", endpoints)
         _, workspace = jgo.resolve_dependencies(
@@ -353,28 +351,6 @@ def is_jvm_headless() -> bool:
 
     GraphicsEnvironment = scyjava.jimport("java.awt.GraphicsEnvironment")
     return bool(GraphicsEnvironment.isHeadless())
-
-
-def is_jvm_available() -> bool:
-    """
-    Return True if the JVM is available, suppressing stderr on macos.
-    """
-    from unittest.mock import patch
-
-    subprocess_check_output = subprocess.check_output
-
-    def _silent_check_output(*args, **kwargs):
-        # also suppress stderr on calls to subprocess.check_output
-        kwargs.setdefault("stderr", subprocess.DEVNULL)
-        return subprocess_check_output(*args, **kwargs)
-
-    try:
-        with patch.object(subprocess, "check_output", new=_silent_check_output):
-            jpype.getDefaultJVMPath()
-    # on Darwin, may raise a CalledProcessError when invoking `/user/libexec/java_home`
-    except (jpype.JVMNotFoundException, subprocess.CalledProcessError):
-        return False
-    return True
 
 
 def is_awt_initialized() -> bool:

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -11,7 +11,6 @@ import sys
 from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
-from typing import Optional
 
 import jpype
 import jpype.config

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -11,6 +11,7 @@ import sys
 from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
+from typing import Optional
 
 import jpype
 import jpype.config
@@ -106,7 +107,7 @@ def jvm_version() -> str:
     return tuple(map(int, m.group(1).split(".")))
 
 
-def start_jvm(options=None, *, fetch_java: bool | None = None) -> None:
+def start_jvm(options=None, *, fetch_java: Optional[bool] = None) -> None:
     """
     Explicitly connect to the Java virtual machine (JVM). Only one JVM can
     be active; does nothing if the JVM has already been started. Calling


### PR DESCRIPTION
this PR adds logic to automatically setup a competent java environment (with a JRE and maven) if one is not already available and `cjdk` is installed (either manually, or via the new `scyjava[cjdk]` extra).  The goal is to enable someone to simply `pip install scyjava[cjdk]`, without having java or maven installed on their system, and have it just work.

there is a new `fetch_java` argument to `start_jvm`, which:
- if None (default), will try to fetch a JRE and maven iff `cjdk` is importable.
- if True, will raise an exception if `cjdk` is not available.
- if False, will fall back to the current behavior of letting an exception raise up if a JVM or maven is unavailable.  

happy to change those defaults too!

(note: this work came from https://github.com/tlambert03/bffile/pull/3 ... but it seems like it might be reasonable to have here too)