### PR TITLE
Configure cjdk behavior via scyjava.config

### DIFF
--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -40,6 +40,22 @@ Use Maven artifacts from remote repositories:
     +++oo*OO######O**oo+++++oo*OO######O**oo+++++oo*OO######O**oo+++
     +++oo*OO######OO*oo+++++oo*OO######OO*oo+++++oo*OO######OO*oo+++
 
+Bootstrap a Java installation:
+
+    >>> from scyjava import config, jimport
+    >>> config.set_java_constraints(fetch=True, vendor='zulu', version='17')
+    >>> System = jimport('java.lang.System')
+    cjdk: Installing JDK zulu:17.0.15 to /home/chuckles/.cache/cjdk
+    Download 100% of 189.4 MiB |##########| Elapsed Time: 0:00:02 Time:  0:00:02
+    Extract | |                 #                    | 714 Elapsed Time: 0:00:01
+    cjdk: Installing Maven to /home/chuckles/.cache/cjdk
+    Download 100% of   8.7 MiB |##########| Elapsed Time: 0:00:00 Time:  0:00:00
+    Extract | |#                                     | 102 Elapsed Time: 0:00:00
+    >>> System.getProperty('java.vendor')
+    'Azul Systems, Inc.'
+    >>> System.getProperty('java.version')
+    '17.0.15'
+
 Convert Java collections to Python:
 
     >>> from scyjava import jimport


### PR DESCRIPTION
This branch updates the awesome JDK/JRE caching to support configuration via the scyjava.config rather than via environment variables.
