### PR TITLE
refactor: delay import of pandas until needed

### DIFF
--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -9,7 +9,7 @@ import math
 from bisect import insort
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Callable, Dict, List, NamedTuple, reveal_type
+from typing import Any, Callable, Dict, List, NamedTuple
 
 from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 


### PR DESCRIPTION
While working on #86, I noticed that scyjava was greedily importing pandas, even when it wasn't being used.  Pandas is somewhat large and can slow down startup; so it would be nice to delay that until we know we need it.

The traditional pattern of `try import` just to know whether something is *importable* can be improved:

1. if you want to know whether something is importable, you can use `importlib.util.find_spec`
2. if you want to know whether someone has *already* imported something (e.g. to check whether some user object is an instance of some third-party type, without unnecessary import), you can look in sys.modules: `sys.modules.get('pandas')`

this PR removes the `_import_X(required=False)` pattern in place of `importlib.util.find_spec`