### PR TITLE
Fix jvm_version parsing of non-numeric version suffixes

### DIFF
--- a/src/scyjava/__init__.py
+++ b/src/scyjava/__init__.py
@@ -84,8 +84,9 @@ Convert Python collections to Java:
 """
 
 import logging
+from collections.abc import Callable
 from functools import lru_cache
-from typing import Any, Callable, Dict
+from typing import Any
 
 from . import config, inspect
 from ._arrays import is_arraylike, is_memoryarraylike, is_xarraylike
@@ -112,7 +113,7 @@ from ._introspect import (
     jreflect,
     jsource,
 )
-from ._jvm import (  # noqa: F401
+from ._jvm import (
     available_processors,
     gc,
     is_awt_initialized,
@@ -161,7 +162,7 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 # Set of module properties
-_CONSTANTS: Dict[str, Callable] = {}
+_CONSTANTS: dict[str, Callable] = {}
 
 
 def constant(func: Callable[[], Any], cache=True) -> Callable[[], Any]:

--- a/src/scyjava/_convert.py
+++ b/src/scyjava/_convert.py
@@ -7,9 +7,10 @@ import inspect
 import logging
 import math
 from bisect import insort
+from collections.abc import Callable
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Callable, Dict, List, NamedTuple
+from typing import Any, NamedTuple
 
 from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 
@@ -52,14 +53,14 @@ class Converter(NamedTuple):
     priority: float = Priority.NORMAL
     name: str = "<unnamed>"
 
-    def supports(self, obj: Any, **hints: Dict) -> bool:
+    def supports(self, obj: Any, **hints: dict) -> bool:
         return (
             self.predicate(obj, **hints)
             if _has_kwargs(self.predicate)
             else self.predicate(obj)
         )
 
-    def convert(self, obj: Any, **hints: Dict) -> Any:
+    def convert(self, obj: Any, **hints: dict) -> Any:
         return (
             self.converter(obj, **hints)
             if _has_kwargs(self.converter)
@@ -82,7 +83,7 @@ class Converter(NamedTuple):
         return self.name
 
 
-def _convert(obj: Any, converters: List[Converter], **hints: Dict) -> Any:
+def _convert(obj: Any, converters: list[Converter], **hints: dict) -> Any:
     # NB: The given converters are assumed to be sorted ascending by priority,
     # meaning lower-priority items appear earlier than higher-priority ones.
     # But we want to try the higher priority converters first, so we
@@ -132,7 +133,7 @@ def _convertIterable(obj: collections.abc.Iterable):
     return jlist
 
 
-java_converters: List[Converter] = []
+java_converters: list[Converter] = []
 
 
 def add_java_converter(converter: Converter) -> None:
@@ -143,7 +144,7 @@ def add_java_converter(converter: Converter) -> None:
     insort(java_converters, converter)
 
 
-def to_java(obj: Any, **hints: Dict) -> Any:
+def to_java(obj: Any, **hints: dict) -> Any:
     """
     Recursively convert a Python object to a Java object.
 
@@ -197,7 +198,7 @@ def to_java(obj: Any, **hints: Dict) -> Any:
     return _convert(obj, java_converters, **hints)
 
 
-def _stock_java_converters() -> List[Converter]:
+def _stock_java_converters() -> list[Converter]:
     """
     Construct the Python-to-Java converters supported out of the box.
     :return: A list of Converters
@@ -366,7 +367,7 @@ def _jstr(data):
     if isinstance(data, JavaObject):
         return str(data)
     # NB: We want Python strings to render in single quotes.
-    return "{!r}".format(data)
+    return f"{data!r}"
 
 
 class JavaObject:
@@ -526,7 +527,7 @@ class JavaSet(JavaCollection, collections.abc.MutableSet):
         return "{" + ", ".join(_jstr(v) for v in self) + "}"
 
 
-py_converters: List[Converter] = []
+py_converters: list[Converter] = []
 
 
 def add_py_converter(converter: Converter) -> None:
@@ -566,13 +567,13 @@ def to_python(data: Any, gentle: bool = False) -> Any:
     start_jvm()
     try:
         return _convert(data, py_converters)
-    except TypeError as exc:
+    except TypeError:
         if gentle:
             return data
-        raise exc
+        raise
 
 
-def _stock_py_converters() -> List:
+def _stock_py_converters() -> list:
     """
     Construct the Java-to-Python converters supported out of the box.
     :return: A list of Converters
@@ -842,7 +843,7 @@ def _is_table(obj: Any) -> bool:
     """Check if obj is a table."""
     try:
         return jinstance(obj, "org.scijava.table.Table")
-    except BaseException:
+    except BaseException:  # noqa: BLE001
         # No worries if scijava-table is not available.
         return False
 
@@ -851,7 +852,7 @@ def _convert_table(obj: Any):
     """Convert obj to a table."""
     try:
         return _table_to_pandas(obj)
-    except BaseException:
+    except BaseException:  # noqa: BLE001
         # No worries if scijava-table is not available.
         return None
 
@@ -894,8 +895,8 @@ def _pandas_to_table(df):
         elif table_type.name.startswith("bool"):
             TableClass = jimport("org.scijava.table.DefaultBoolTable")
         else:
-            msg = "The type '{}' is not supported.".format(table_type.name)
-            raise Exception(msg)
+            msg = f"The type '{table_type.name}' is not supported."
+            raise ValueError(msg)
 
     table = TableClass(*df.shape[::-1])
 
@@ -913,51 +914,51 @@ def _pandas_to_table(df):
 # fmt: off
 class _JavaClasses(JavaClasses):
     @JavaClasses.java_import
-    def Boolean(self):       return "java.lang.Boolean"        # noqa: E272
+    def Boolean(self):       return "java.lang.Boolean"
     @JavaClasses.java_import
-    def Byte(self):          return "java.lang.Byte"           # noqa: E272
+    def Byte(self):          return "java.lang.Byte"
     @JavaClasses.java_import
-    def Character(self):     return "java.lang.Character"      # noqa: E272
+    def Character(self):     return "java.lang.Character"
     @JavaClasses.java_import
-    def Double(self):        return "java.lang.Double"         # noqa: E272
+    def Double(self):        return "java.lang.Double"
     @JavaClasses.java_import
-    def Float(self):         return "java.lang.Float"          # noqa: E272
+    def Float(self):         return "java.lang.Float"
     @JavaClasses.java_import
-    def Integer(self):       return "java.lang.Integer"        # noqa: E272
+    def Integer(self):       return "java.lang.Integer"
     @JavaClasses.java_import
-    def Iterable(self):      return "java.lang.Iterable"       # noqa: E272
+    def Iterable(self):      return "java.lang.Iterable"
     @JavaClasses.java_import
-    def Long(self):          return "java.lang.Long"           # noqa: E272
+    def Long(self):          return "java.lang.Long"
     @JavaClasses.java_import
-    def Object(self):        return "java.lang.Object"         # noqa: E272
+    def Object(self):        return "java.lang.Object"
     @JavaClasses.java_import
-    def Short(self):         return "java.lang.Short"          # noqa: E272
+    def Short(self):         return "java.lang.Short"
     @JavaClasses.java_import
-    def String(self):        return "java.lang.String"         # noqa: E272
+    def String(self):        return "java.lang.String"
     @JavaClasses.java_import
-    def BigDecimal(self):    return "java.math.BigDecimal"     # noqa: E272
+    def BigDecimal(self):    return "java.math.BigDecimal"
     @JavaClasses.java_import
-    def BigInteger(self):    return "java.math.BigInteger"     # noqa: E272
+    def BigInteger(self):    return "java.math.BigInteger"
     @JavaClasses.java_import
-    def Path(self):          return "java.nio.file.Path"       # noqa: E272
+    def Path(self):          return "java.nio.file.Path"
     @JavaClasses.java_import
-    def Paths(self):         return "java.nio.file.Paths"      # noqa: E272
+    def Paths(self):         return "java.nio.file.Paths"
     @JavaClasses.java_import
-    def ArrayList(self):     return "java.util.ArrayList"      # noqa: E272
+    def ArrayList(self):     return "java.util.ArrayList"
     @JavaClasses.java_import
-    def Collection(self):    return "java.util.Collection"     # noqa: E272
+    def Collection(self):    return "java.util.Collection"
     @JavaClasses.java_import
-    def Iterator(self):      return "java.util.Iterator"       # noqa: E272
+    def Iterator(self):      return "java.util.Iterator"
     @JavaClasses.java_import
-    def LinkedHashMap(self): return "java.util.LinkedHashMap"  # noqa: E272
+    def LinkedHashMap(self): return "java.util.LinkedHashMap"
     @JavaClasses.java_import
-    def LinkedHashSet(self): return "java.util.LinkedHashSet"  # noqa: E272
+    def LinkedHashSet(self): return "java.util.LinkedHashSet"
     @JavaClasses.java_import
-    def List(self):          return "java.util.List"           # noqa: E272
+    def List(self):          return "java.util.List"
     @JavaClasses.java_import
-    def Map(self):           return "java.util.Map"            # noqa: E272
+    def Map(self):           return "java.util.Map"
     @JavaClasses.java_import
-    def Set(self):           return "java.util.Set"            # noqa: E272
+    def Set(self):           return "java.util.Set"
 # fmt: on
 
 

--- a/src/scyjava/_introspect.py
+++ b/src/scyjava/_introspect.py
@@ -3,13 +3,13 @@ Introspection functions for reporting Java
 class methods, fields, and source code URL.
 """
 
-from typing import Any, Dict, List
+from typing import Any
 
 from scyjava._jvm import jimport, jvm_version
-from scyjava._types import isjava, jinstance, jclass
+from scyjava._types import isjava, jclass, jinstance
 
 
-def jreflect(data, aspect: str = "all") -> List[Dict[str, Any]]:
+def jreflect(data, aspect: str = "all") -> list[dict[str, Any]]:
     """
     Use Java reflection to introspect the given Java object,
     returning a table of its available methods or fields.
@@ -91,7 +91,7 @@ def jsource(data) -> str:
         try:
             data = jimport(data)  # check if data can be imported
         except Exception as err:
-            raise ValueError(f"Not a Java object {err}")
+            raise ValueError(f"Not a Java object {err}") from err
     jcls = data if jinstance(data, "java.lang.Class") else jclass(data)
 
     if jcls.getClassLoader() is None:

--- a/src/scyjava/_jdk_fetch.py
+++ b/src/scyjava/_jdk_fetch.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from jgo.exec import JavaLocator, JavaSource
 
@@ -64,7 +64,7 @@ def resolve_java(vendor: str | None = None, version: str | None = None) -> None:
     os.environ["JAVA_HOME"] = str(java_home)
 
 
-def _add_to_path(path: Union[Path, str], front: bool = False) -> None:
+def _add_to_path(path: Path | str, front: bool = False) -> None:
     """Add a path to the PATH environment variable.
 
     If front is True, the path is added to the front of the PATH.

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -135,7 +135,7 @@ def jvm_version() -> tuple[int, ...]:
 
 def _jvm_version_str_to_tuple(java_version_output: str, java: str) -> tuple[int, ...]:
     java_version_output = java_version_output.replace("\n", " ").replace("\r", "")
-    m = re.match('.* version "([^"]*)"', java_version_output)
+    m = re.match(r'.*version "(\d+(?:\.\d+)*)', java_version_output)
     if not m:
         raise RuntimeError(
             f"Inscrutable java command output:\n$ {java} -version\n{java_version_output}"

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -130,11 +130,15 @@ def jvm_version() -> tuple[int, ...]:
     except subprocess.CalledProcessError as e:
         raise RuntimeError("System call to java failed") from e
 
-    output = output.replace("\n", " ").replace("\r", "")
-    m = re.match('.* version "([^"]*)"', output)
+    return _jvm_version_str_to_tuple(output, java)
+
+
+def _jvm_version_str_to_tuple(java_version_output: str, java: str) -> tuple[int, ...]:
+    java_version_output = java_version_output.replace("\n", " ").replace("\r", "")
+    m = re.match('.* version "([^"]*)"', java_version_output)
     if not m:
         raise RuntimeError(
-            f"Inscrutable java command output:\n$ {java} -version\n{output}"
+            f"Inscrutable java command output:\n$ {java} -version\n{java_version_output}"
         )
 
     v = m.group(1)

--- a/src/scyjava/_jvm.py
+++ b/src/scyjava/_jvm.py
@@ -8,18 +8,18 @@ import os
 import re
 import subprocess
 import sys
-from functools import lru_cache
+from collections.abc import Sequence
+from functools import cache
 from importlib import import_module
 from pathlib import Path
-from typing import Sequence
 
+import jgo
 import jpype
 import jpype.config
-import jgo
 
 import scyjava.config
-from scyjava.config import Mode, mode
 from scyjava._jdk_fetch import resolve_java
+from scyjava.config import Mode, mode
 
 _logger = logging.getLogger(__name__)
 
@@ -176,7 +176,7 @@ def start_jvm(options: Sequence[str] | None = None) -> None:
     repositories = scyjava.config.get_repositories()
 
     # use the logger to notify user that endpoints are being added
-    _logger.debug("Adding jars from endpoints {0}".format(endpoints))
+    _logger.debug(f"Adding jars from endpoints {endpoints}")
 
     # download Java as appropriate
     resolve_java()
@@ -297,7 +297,7 @@ def shutdown_jvm() -> None:
     for callback in _shutdown_callbacks:
         try:
             callback()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             _logger.error(f"Exception during shutdown callback: {e}")
 
     # dispose AWT resources if applicable
@@ -309,7 +309,7 @@ def shutdown_jvm() -> None:
     # okay to shutdown JVM
     try:
         jpype.shutdownJVM()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         _logger.error(f"Exception during JVM shutdown: {e}")
 
 
@@ -444,7 +444,6 @@ def when_jvm_starts(f) -> None:
         f()
     else:
         # Add function to the list of callbacks to invoke upon start_jvm().
-        global _startup_callbacks
         _startup_callbacks.append(f)
 
 
@@ -458,11 +457,10 @@ def when_jvm_stops(f) -> None:
 
     :param f: Function to invoke when scyjava.shutdown_jvm() is called.
     """
-    global _shutdown_callbacks
     _shutdown_callbacks.append(f)
 
 
-@lru_cache(maxsize=None)
+@cache
 def jimport(class_name: str):
     """
     Import a class from Java to Python.

--- a/src/scyjava/_script.py
+++ b/src/scyjava/_script.py
@@ -67,7 +67,7 @@ def enable_python_scripting(context):
         def apply(self, arg):
             # Copy script bindings/vars into script locals.
             script_locals = {}
-            for key in arg.vars.keys():
+            for key in arg.vars:
                 script_locals[key] = arg.vars[key]
 
             stdoutContextWriter.addScriptContext(
@@ -100,7 +100,7 @@ def enable_python_scripting(context):
                     # See: https://docs.python.org/3/library/functions.html#exec
                     _globals = script_locals
 
-                    exec(
+                    exec(  # noqa: S102
                         compile(block, "<string>", mode="exec"), _globals, script_locals
                     )
                     if last is not None:
@@ -109,7 +109,7 @@ def enable_python_scripting(context):
                             _globals,
                             script_locals,
                         )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     error_message = traceback.format_exc()
                     error_writer = arg.scriptContext.getErrorWriter()
                     if error_writer is None:
@@ -123,11 +123,11 @@ def enable_python_scripting(context):
             stdoutContextWriter.removeScriptContext(threading.currentThread())
 
             # Copy script locals back into script bindings/vars.
-            for key in script_locals.keys():
+            for key, value in script_locals.items():
                 try:
-                    arg.vars[key] = to_java(script_locals[key])
-                except Exception:
-                    arg.vars[key] = PythonObjectSupplier(script_locals[key])
+                    arg.vars[key] = to_java(value)
+                except Exception:  # noqa: BLE001
+                    arg.vars[key] = PythonObjectSupplier(value)
 
             return to_java(return_value)
 

--- a/src/scyjava/_types.py
+++ b/src/scyjava/_types.py
@@ -2,7 +2,8 @@
 Utility functions for working with and reasoning about Java types.
 """
 
-from typing import Any, Callable, Sequence, Tuple, Union
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import jpype
 
@@ -50,7 +51,7 @@ class JavaClasses:
         @property
         def inner(self):
             if not jvm_started():
-                raise Exception()
+                raise RuntimeError("The JVM has not been started yet.")
             try:
                 return jimport(func(self))
             except TypeError:
@@ -128,7 +129,7 @@ def jstacktrace(exc) -> str:
         sw = StringWriter()
         exc.printStackTrace(PrintWriter(sw, True))
         return str(sw)
-    except BaseException:
+    except BaseException:  # noqa: BLE001
         return ""
 
 
@@ -138,7 +139,7 @@ def isjava(data) -> bool:
         return jinstance(data, "java.lang.Object")
 
     assert mode == Mode.JPYPE
-    return isinstance(data, jpype.JClass) or isinstance(data, jpype.JObject)
+    return isinstance(data, (jpype.JClass, jpype.JObject))
 
 
 def is_jbyte(the_type: type) -> bool:
@@ -227,7 +228,7 @@ def jarray(kind, lengths: Sequence):
     arraytype = kind
 
     if mode == Mode.JEP:
-        import jep  # noqa: F401
+        import jep
 
         if len(lengths) == 1:
             # Fast case: 1-d array (we can use primitives)
@@ -286,7 +287,7 @@ def jarray(kind, lengths: Sequence):
 
 def numeric_bounds(
     the_type: type,
-) -> Union[Tuple[int, int], Tuple[float, float], Tuple[None, None]]:
+) -> tuple[int, int] | tuple[float, float] | tuple[None, None]:
     """
     Get the minimum and maximum values for the given numeric type.
     For example, a Java long returns (int(Long.MIN_VALUE), int(Long.MAX_VALUE)),

--- a/src/scyjava/config.py
+++ b/src/scyjava/config.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import enum as _enum
 import logging as _logging
 import os as _os
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import jpype as _jpype
-
 
 _SCIJAVA_PUBLIC = "https://maven.scijava.org/content/groups/public"
 
@@ -146,7 +145,6 @@ def add_repositories(*args, **kwargs) -> None:
     Add one or more Maven repositories to be used by jgo for downloading dependencies.
     See the jgo documentation for details.
     """
-    global _repositories
     for arg in args:
         _logger.debug("Adding repositories %s to %s", arg, _repositories)
         _repositories.update(arg)
@@ -159,7 +157,6 @@ def get_repositories() -> dict[str, str]:
     Get the Maven repositories jgo will use for downloading dependencies.
     See the jgo documentation for details.
     """
-    global _repositories
     return _repositories
 
 
@@ -179,7 +176,6 @@ def get_verbose() -> int:
     """
     Get the level of verbosity for logging environment construction details.
     """
-    global _verbose
     _logger.debug("Getting verbose level: %d", _verbose)
     return _verbose
 
@@ -199,7 +195,6 @@ def get_manage_deps() -> bool:
     Get whether jgo will resolve dependencies in managed mode.
     See the jgo documentation for details.
     """
-    global _manage_deps
     return _manage_deps
 
 
@@ -218,7 +213,6 @@ def get_cache_dir() -> Path:
     Get the location to use for the jgo environment cache.
     See the jgo documentation for details.
     """
-    global _cache_dir
     return _cache_dir
 
 
@@ -235,7 +229,6 @@ def get_m2_repo() -> Path:
     """
     Get the location to use for the local Maven repository cache.
     """
-    global _m2_repo
     return _m2_repo
 
 
@@ -291,7 +284,7 @@ def get_classpath() -> str:
     return _jpype.getClassPath()
 
 
-def set_heap_min(mb: int = None, gb: int = None) -> None:
+def set_heap_min(mb: int | None = None, gb: int | None = None) -> None:
     """
     Set the initial amount of memory to allocate to the Java heap.
 
@@ -308,7 +301,7 @@ def set_heap_min(mb: int = None, gb: int = None) -> None:
     add_option(f"-Xms{_mem_value(mb, gb)}")
 
 
-def set_heap_max(mb: int = None, gb: int = None) -> None:
+def set_heap_max(mb: int | None = None, gb: int | None = None) -> None:
     """
     Shortcut for passing -Xmx###m or -Xmx###g to Java.
 
@@ -323,10 +316,10 @@ def set_heap_max(mb: int = None, gb: int = None) -> None:
     add_option(f"-Xmx{_mem_value(mb, gb)}")
 
 
-def _mem_value(mb: int = None, gb: int = None) -> str:
+def _mem_value(mb: int | None = None, gb: int | None = None) -> str:
     # fmt: off
-    if mb is not None and gb is None: return f"{mb}m"  # noqa: E701
-    if gb is not None and mb is None: return f"{gb}g"  # noqa: E701
+    if mb is not None and gb is None: return f"{mb}m"
+    if gb is not None and mb is None: return f"{gb}g"
     # fmt: on
     raise ValueError("Exactly one of mb or gb must be given.")
 
@@ -372,7 +365,6 @@ def add_option(option: str) -> None:
     :param option:
         The option to add.
     """
-    global _options
     _options.append(option)
 
 
@@ -383,7 +375,6 @@ def add_options(options: str | Sequence) -> None:
     :param options:
         Sequence of options to add, or single string to pass as an individual option.
     """
-    global _options
     if isinstance(options, str):
         _options.append(options)
     else:
@@ -394,7 +385,6 @@ def get_options() -> list[str]:
     """
     Get the list of options to be passed at JVM startup.
     """
-    global _options
     return _options
 
 
@@ -407,7 +397,6 @@ def add_kwargs(**kwargs) -> None:
         convertStrings = True
         interrupt = True
     """
-    global _kwargs
     _kwargs.update(kwargs)
 
 
@@ -415,7 +404,6 @@ def get_kwargs() -> dict[str, str]:
     """
     Get the keyword arguments to be passed to JPype at JVM startup.
     """
-    global _kwargs
     return _kwargs
 
 
@@ -424,7 +412,6 @@ def add_shortcut(k: str, v: str):
     Add a shortcut key/value to be used by jgo for evaluating endpoints.
     See the jgo documentation for details.
     """
-    global _shortcuts
     _shortcuts[k] = v
 
 
@@ -433,7 +420,6 @@ def get_shortcuts() -> dict[str, str]:
     Get the dictionary of shorts that jgo will use for evaluating endpoints.
     See the jgo documentation for details.
     """
-    global _shortcuts
     return _shortcuts
 
 
@@ -446,7 +432,6 @@ def add_endpoints(*new_endpoints):
         "Deprecated method call: scyjava.config.add_endpoints(). "
         "Please modify scyjava.config.endpoints directly instead."
     )
-    global endpoints
     _logger.debug("Adding endpoints %s to %s", new_endpoints, endpoints)
     endpoints.extend(new_endpoints)
 
@@ -460,12 +445,11 @@ def get_endpoints():
         "Deprecated method call: scyjava.config.get_endpoints(). "
         "Please access scyjava.config.endpoints directly instead."
     )
-    global endpoints
     return endpoints
 
 
-_maven_url: str = "tgz+https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz"  # noqa: E501
-_maven_sha: str = "a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b"  # noqa: E501
+_maven_url: str = "tgz+https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz"
+_maven_sha: str = "a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b"
 
 
 def get_maven_url() -> str:

--- a/src/scyjava/inspect.py
+++ b/src/scyjava/inspect.py
@@ -144,7 +144,7 @@ def _print_data(
         return
 
     # Print source code
-    offset = max(list(map(lambda entry: len(entry["returns"] or "void"), table)))
+    offset = max(len(entry["returns"] or "void") for entry in table)
     all_methods = ""
     if source or source is None:
         try:
@@ -162,14 +162,13 @@ def _print_data(
             entry["returns"] = _map_syntax(entry["returns"])
         if entry["arguments"]:
             entry["arguments"] = [_map_syntax(e) for e in entry["arguments"]]
-        if static is None:
-            entry_string = _pretty_string(entry, offset)
-            all_methods += entry_string
-
-        elif static and "static" in entry["mods"]:
-            entry_string = _pretty_string(entry, offset)
-            all_methods += entry_string
-        elif not static and "static" not in entry["mods"]:
+        if (
+            static is None
+            or static
+            and "static" in entry["mods"]
+            or not static
+            and "static" not in entry["mods"]
+        ):
             entry_string = _pretty_string(entry, offset)
             all_methods += entry_string
         else:

--- a/tests/it/awt.py
+++ b/tests/it/awt.py
@@ -5,9 +5,9 @@ Test scyjava AWT-related functions.
 import platform
 import sys
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 if platform.system() == "Darwin":
     # NB: This test would hang on macOS, due to AWT threading issues.

--- a/tests/it/headless.py
+++ b/tests/it/headless.py
@@ -2,9 +2,9 @@
 Test scyjava headless mode.
 """
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 scyjava.config.enable_headless_mode()
 

--- a/tests/it/java_heap.py
+++ b/tests/it/java_heap.py
@@ -2,9 +2,9 @@
 Test scyjava JVM memory-related functions.
 """
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 mb_initial = 50  # initial MB of memory to snarf up
 mb_tolerance = 10  # ceiling of expected MB in use

--- a/tests/it/jvm_version.py
+++ b/tests/it/jvm_version.py
@@ -2,9 +2,9 @@
 Test the jvm_version() function.
 """
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 assert_that(scyjava.jvm_started()).is_false()
 

--- a/tests/it/script_scope.py
+++ b/tests/it/script_scope.py
@@ -4,9 +4,9 @@ Test the enable_python_scripting function, but here explictly testing import sco
 
 import sys
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 scyjava.config.endpoints.extend(
     ["org.scijava:scijava-common:2.94.2", "org.scijava:scripting-python:MANAGED"]
@@ -59,7 +59,7 @@ except Exception as e:
     trace = scyjava.jstacktrace(e)
     if trace:
         sys.stderr.write(f"{trace}\n")
-    raise e
+    raise
 
 assert_that(statement).is_equal_to("2")
 assert_that(return_value).is_equal_to("The rounded cube root of my age is 2")

--- a/tests/it/scripting.py
+++ b/tests/it/scripting.py
@@ -7,9 +7,9 @@ As a side effect, this script also tests Maven dependency resolution.
 
 import sys
 
-import scyjava
-
 from assertpy import assert_that
+
+import scyjava
 
 scyjava.config.endpoints.extend(
     ["org.scijava:scijava-common:2.94.2", "org.scijava:scripting-python:MANAGED"]
@@ -56,7 +56,7 @@ except Exception as e:
     trace = scyjava.jstacktrace(e)
     if trace:
         sys.stderr.write(f"{trace}\n")
-    raise e
+    raise
 
 assert_that(statement).is_equal_to(
     "Hello, Chuckles! In one year you will be 14 years old."

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -8,7 +8,7 @@ from scyjava import is_jarray, jarray, to_python
 from scyjava.config import Mode, mode
 
 
-class TestArrays(object):
+class TestArrays:
     def test_non_primitive_jarray(self):
         pass
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -10,7 +10,7 @@ import scyjava
 from scyjava.config import Mode, mode
 
 
-class TestBasics(object):
+class TestBasics:
     """
     Test basic scyjava functions.
     """

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -28,7 +28,7 @@ config.endpoints.append("org.scijava:scijava-table")
 config.enable_headless_mode()
 
 
-class TestConvert(object):
+class TestConvert:
     def testClass(self):
         """
         Test class detection from Java objects.
@@ -167,7 +167,7 @@ class TestConvert(object):
         assert ostring == pstring
 
     def testList(self):
-        olist = "The quick brown fox jumps over the lazy dogs".split()
+        olist = ["The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dogs"]
         jlist = to_java(olist)
         for e, a in zip(olist, jlist):
             assert e == to_python(a)
@@ -179,7 +179,7 @@ class TestConvert(object):
         assert "The quick brown fox jumps over the silly dogs" == " ".join(plist)
 
     def testSet(self):
-        s = set(["orange", "apple", "pineapple", "plum"])
+        s = {"orange", "apple", "pineapple", "plum"}
         js = to_java(s)
         assert len(s) == js.size()
         for e in s:
@@ -262,7 +262,7 @@ class TestConvert(object):
     def testMixed(self):
         test_dict = {"a": "b", "c": "d"}
         test_list = ["e", "f", "g", "h"]
-        test_set = set(["i", "j", "k"])
+        test_set = {"i", "j", "k"}
 
         # mixed types in a dictionary
         mixed_dict = {"d": test_dict, "l": test_list, "s": test_set, "str": "hello"}
@@ -303,7 +303,7 @@ class TestConvert(object):
         bad_conversion = None
         try:
             bad_conversion = to_python(unknown_thing)
-        except BaseException:
+        except TypeError:
             # NB: Failure is expected here.
             pass
         assert bad_conversion is None

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -5,10 +5,10 @@ Tests for functions in inspect submodule.
 import re
 
 from scyjava import inspect
-from scyjava.config import mode, Mode
+from scyjava.config import Mode, mode
 
 
-class TestInspect(object):
+class TestInspect:
     """
     Test scyjava.inspect convenience functions.
     """
@@ -20,8 +20,10 @@ class TestInspect(object):
         members = []
         inspect.members("java.lang.Iterable", writer=members.append)
         expected = [
-            "Source code URL: https://github.com/openjdk/jdk/blob/"
-            ".../share/classes/java/lang/Iterable.java",
+            (
+                "Source code URL: https://github.com/openjdk/jdk/blob/"
+                ".../share/classes/java/lang/Iterable.java"
+            ),
             "                         * indicates static modifier",
             "java.util.Iterator         = iterator()",
             "java.util.Spliterator      = spliterator()",

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -13,7 +13,7 @@ scyjava.config.endpoints.extend(
 )
 
 
-class TestIntrospection(object):
+class TestIntrospection:
     """
     Test introspection functionality.
     """

--- a/tests/test_jvm_version.py
+++ b/tests/test_jvm_version.py
@@ -8,8 +8,15 @@ from scyjava._jvm import _jvm_version_str_to_tuple
 def test_jvm_version():
     assert _jvm_version_str_to_tuple(' version "17.0.1"', "java") == (17, 0, 1)
     assert _jvm_version_str_to_tuple(' version "17.0.18-internal"', "java") == (
-        17, 0, 18)
+        17,
+        0,
+        18,
+    )
     assert _jvm_version_str_to_tuple(' version "11.0.9.1-internal"', "java") == (
-        11, 0, 9, 1)
+        11,
+        0,
+        9,
+        1,
+    )
     assert _jvm_version_str_to_tuple(' version "1.8.0_312"', "java") == (1, 8, 0)
     assert _jvm_version_str_to_tuple(' version "25"', "java") == (25,)

--- a/tests/test_jvm_version.py
+++ b/tests/test_jvm_version.py
@@ -1,0 +1,15 @@
+"""
+Tests for functions in _versions submodule.
+"""
+
+from scyjava._jvm import _jvm_version_str_to_tuple
+
+
+def test_jvm_version():
+    assert _jvm_version_str_to_tuple(' version "17.0.1"', "java") == (17, 0, 1)
+    assert _jvm_version_str_to_tuple(' version "17.0.18-internal"', "java") == (
+        17, 0, 18)
+    assert _jvm_version_str_to_tuple(' version "11.0.9.1-internal"', "java") == (
+        11, 0, 9, 1)
+    assert _jvm_version_str_to_tuple(' version "1.8.0_312"', "java") == (1, 8, 0)
+    assert _jvm_version_str_to_tuple(' version "25"', "java") == (25,)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -22,7 +22,7 @@ def assert_same_table(table, df):
         assert table.getColumnHeader(i) == df.columns[i]
 
 
-class TestPandas(object):
+class TestPandas:
     def testPandasToTable(self):
         columns = ["header1", "header2", "header3", "header4", "header5"]
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from scyjava import jclass, jimport, numeric_bounds, to_java
 from scyjava.config import Mode, mode
 
 
-class TestTypes(object):
+class TestTypes:
     """
     Test Java-type-related functions.
     """


### PR DESCRIPTION
The old regex captured the entire quoted version string, including
non-numeric suffixes like "-internal" or "_312", which broke int()
conversion downstream. Now only the leading dot-separated digit
groups are captured.

Extract jvm_version parsing into a testable helper function.

Closes #91.